### PR TITLE
fix: only set deployment if one exists

### DIFF
--- a/api/lagoon/client/deployments.go
+++ b/api/lagoon/client/deployments.go
@@ -123,10 +123,10 @@ func (c *Client) DeploymentByBuildName(
 	if err != nil {
 		return err
 	}
-	d := environment.Deployments[0]
 	if len(environment.Deployments) == 0 {
 		return fmt.Errorf("no deployment found for environment")
 	}
+	d := environment.Deployments[0]
 	db, _ := json.Marshal(d)
 	json.Unmarshal(db, deployment)
 	return nil


### PR DESCRIPTION
just a minor fix in order of operations on checking if a deployment exists in the returned data