### PR TITLE
Remove MonitoringURLs support

### DIFF
--- a/api/schema/environment.go
+++ b/api/schema/environment.go
@@ -93,7 +93,6 @@ type UpdateEnvironmentPatchInput struct {
 	OpenshiftProjectName *string     `json:"openshiftProjectName,omitempty"`
 	Route                *string     `json:"route,omitempty"`
 	Routes               *string     `json:"routes,omitempty"`
-	MonitoringURLs       *string     `json:"monitoringUrls,omitempty"`
 	AutoIdle             *uint       `json:"autoIdle,omitempty"`
 	Openshift            *uint       `json:"openshift,omitempty"`
 	Created              *string     `json:"created,omitempty"`

--- a/api/schema/logs.go
+++ b/api/schema/logs.go
@@ -9,31 +9,30 @@ type LagoonMessage struct {
 
 // LagoonLogMeta is the metadata that is used by logging in Lagoon.
 type LagoonLogMeta struct {
-	BranchName     string          `json:"branchName,omitempty"`
-	BuildName      string          `json:"buildName,omitempty"`
-	BuildStatus    string          `json:"buildStatus,omitempty"`
-	BuildPhase     string          `json:"buildPhase,omitempty"` // legacy but still used until `buildStatus` is more available
-	BuildStep      string          `json:"buildStep,omitempty"`
-	EndTime        string          `json:"endTime,omitempty"`
-	Environment    string          `json:"environment,omitempty"`
-	EnvironmentID  *uint           `json:"environmentId,omitempty"`
-	JobName        string          `json:"jobName,omitempty"`   // used by tasks/jobs
-	JobStatus      string          `json:"jobStatus,omitempty"` // used by tasks/jobs
-	JobStep        string          `json:"jobStep,omitempty"`   // used by tasks/jobs
-	LogLink        string          `json:"logLink,omitempty"`
-	MonitoringURLs []string        `json:"monitoringUrls,omitempty"`
-	Project        string          `json:"project,omitempty"`
-	ProjectID      *uint           `json:"projectId,omitempty"`
-	ProjectName    string          `json:"projectName,omitempty"`
-	RemoteID       string          `json:"remoteId,omitempty"`
-	Route          string          `json:"route,omitempty"`
-	Routes         []string        `json:"routes,omitempty"`
-	StartTime      string          `json:"startTime,omitempty"`
-	Services       []string        `json:"services,omitempty"`
-	Task           *LagoonTaskInfo `json:"task,omitempty"`
-	Key            string          `json:"key,omitempty"`
-	AdvancedData   string          `json:"advancedData,omitempty"`
-	Cluster        string          `json:"clusterName,omitempty"`
+	BranchName    string          `json:"branchName,omitempty"`
+	BuildName     string          `json:"buildName,omitempty"`
+	BuildStatus   string          `json:"buildStatus,omitempty"`
+	BuildPhase    string          `json:"buildPhase,omitempty"` // legacy but still used until `buildStatus` is more available
+	BuildStep     string          `json:"buildStep,omitempty"`
+	EndTime       string          `json:"endTime,omitempty"`
+	Environment   string          `json:"environment,omitempty"`
+	EnvironmentID *uint           `json:"environmentId,omitempty"`
+	JobName       string          `json:"jobName,omitempty"`   // used by tasks/jobs
+	JobStatus     string          `json:"jobStatus,omitempty"` // used by tasks/jobs
+	JobStep       string          `json:"jobStep,omitempty"`   // used by tasks/jobs
+	LogLink       string          `json:"logLink,omitempty"`
+	Project       string          `json:"project,omitempty"`
+	ProjectID     *uint           `json:"projectId,omitempty"`
+	ProjectName   string          `json:"projectName,omitempty"`
+	RemoteID      string          `json:"remoteId,omitempty"`
+	Route         string          `json:"route,omitempty"`
+	Routes        []string        `json:"routes,omitempty"`
+	StartTime     string          `json:"startTime,omitempty"`
+	Services      []string        `json:"services,omitempty"`
+	Task          *LagoonTaskInfo `json:"task,omitempty"`
+	Key           string          `json:"key,omitempty"`
+	AdvancedData  string          `json:"advancedData,omitempty"`
+	Cluster       string          `json:"clusterName,omitempty"`
 }
 
 // LagoonTaskInfo defines what a task can use to communicate with Lagoon via SSH/API.


### PR DESCRIPTION
Part of https://github.com/uselagoon/lagoon/issues/2975

The remote-controller no longer sends `MonitoringURLs` so we can remove the reference in the `LagoonLogMeta` struct. 

Since machinery is an "internal" (to lagoon) tool and we are dropping monitoring urls, I removed it from `UpdateEnvironmentPatchInput` too. It could technically stay in so that machinery matches the API schema exactly, but I don't think that provides any benefits?