### PR TITLE
chore: add support for uploading files to tasks

### DIFF
--- a/api/lagoon/client/_lgraphql/tasks/uploadFilesForTask.graphql
+++ b/api/lagoon/client/_lgraphql/tasks/uploadFilesForTask.graphql
@@ -1,0 +1,1 @@
+mutation ( $task: Int!, $files: [Upload!]!) { uploadFilesForTask(input:{task:$task, files:$files}) {id name status files { filename } } }

--- a/api/lagoon/client/client.go
+++ b/api/lagoon/client/client.go
@@ -20,6 +20,7 @@ import (
 type Client struct {
 	userAgent string
 	token     *string
+	endpoint  string
 	client    *graphql.Client
 }
 
@@ -29,6 +30,7 @@ func New(endpoint, userAgent string, token *string, debug bool) *Client {
 		return &Client{
 			userAgent: userAgent,
 			token:     token,
+			endpoint:  endpoint,
 			client: graphql.NewClient(endpoint,
 				// enable debug logging to stderr
 				func(c *graphql.Client) {
@@ -42,6 +44,7 @@ func New(endpoint, userAgent string, token *string, debug bool) *Client {
 	return &Client{
 		userAgent: userAgent,
 		token:     token,
+		endpoint:  endpoint,
 		client:    graphql.NewClient(endpoint),
 	}
 }

--- a/api/lagoon/client/lgraphql/lgraphql.go
+++ b/api/lagoon/client/lgraphql/lgraphql.go
@@ -46,6 +46,7 @@
 // _lgraphql/environments/updateEnvironment.graphql
 // _lgraphql/tasks/switchActiveStandby.graphql
 // _lgraphql/tasks/updateTask.graphql
+// _lgraphql/tasks/uploadFilesForTask.graphql
 // _lgraphql/usergroups/addGroup.graphql
 // _lgraphql/usergroups/addGroupsToProject.graphql
 // _lgraphql/usergroups/addSshKey.graphql
@@ -1051,6 +1052,26 @@ func _lgraphqlTasksUpdatetaskGraphql() (*asset, error) {
 	return a, nil
 }
 
+var __lgraphqlTasksUploadfilesfortaskGraphql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\x24\x8c\x41\x0a\x83\x40\x0c\x45\xaf\xf2\x07\x5c\x28\x78\x82\x39\x80\xd0\x7d\xbb\x2a\x5d\x04\xb4\x30\xa8\x19\x69\x92\x55\xf0\xee\x65\x32\x64\x11\x92\xc7\x7b\xa7\x29\x69\xa9\x8c\x11\x83\x92\xec\x19\x0f\xd6\x34\x63\xf8\x96\x63\x93\x8c\xf7\xeb\x3a\x2a\xad\xe9\x93\x26\x38\x2c\x8e\xa5\xa1\xa5\xfe\x9e\x24\xfb\x58\xf8\x32\xcd\x1e\x6e\x14\x66\x74\xb5\x17\xee\x09\x5e\x56\x30\x9d\x1b\x44\x49\x4d\x3a\x86\xc7\x8e\xff\xdd\xe6\x1f\x00\x00\xff\xff\x4f\x59\x28\x5d\x89\x00\x00\x00")
+
+func _lgraphqlTasksUploadfilesfortaskGraphqlBytes() ([]byte, error) {
+	return bindataRead(
+		__lgraphqlTasksUploadfilesfortaskGraphql,
+		"_lgraphql/tasks/uploadFilesForTask.graphql",
+	)
+}
+
+func _lgraphqlTasksUploadfilesfortaskGraphql() (*asset, error) {
+	bytes, err := _lgraphqlTasksUploadfilesfortaskGraphqlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "_lgraphql/tasks/uploadFilesForTask.graphql", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var __lgraphqlUsergroupsAddgroupGraphql = []byte("\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\xff\xca\x2d\x2d\x49\x2c\xc9\xcc\xcf\x53\xd0\xe0\x52\x50\x50\xc9\x4b\xcc\x4d\xb5\x52\x08\x2e\x29\xca\xcc\x4b\x57\xd4\x54\xa8\xe6\x52\x50\x50\x50\x48\x4c\x49\x71\x2f\xca\x2f\x2d\xd0\xc8\xcc\x2b\x28\x2d\xb1\x82\x8a\x2a\x28\x40\x14\x83\xf5\x80\x45\x6a\x35\xe1\x52\x99\x29\x48\x6a\x20\x92\x5c\x20\x0c\x08\x00\x00\xff\xff\x33\xcc\xe8\xad\x6e\x00\x00\x00")
 
 func _lgraphqlUsergroupsAddgroupGraphqlBytes() ([]byte, error) {
@@ -1329,6 +1350,7 @@ var _bindata = map[string]func() (*asset, error){
 	"_lgraphql/environments/updateEnvironment.graphql":                     _lgraphqlEnvironmentsUpdateenvironmentGraphql,
 	"_lgraphql/tasks/switchActiveStandby.graphql":                          _lgraphqlTasksSwitchactivestandbyGraphql,
 	"_lgraphql/tasks/updateTask.graphql":                                   _lgraphqlTasksUpdatetaskGraphql,
+	"_lgraphql/tasks/uploadFilesForTask.graphql":                           _lgraphqlTasksUploadfilesfortaskGraphql,
 	"_lgraphql/usergroups/addGroup.graphql":                                _lgraphqlUsergroupsAddgroupGraphql,
 	"_lgraphql/usergroups/addGroupsToProject.graphql":                      _lgraphqlUsergroupsAddgroupstoprojectGraphql,
 	"_lgraphql/usergroups/addSshKey.graphql":                               _lgraphqlUsergroupsAddsshkeyGraphql,
@@ -1439,6 +1461,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 		"tasks": &bintree{nil, map[string]*bintree{
 			"switchActiveStandby.graphql": &bintree{_lgraphqlTasksSwitchactivestandbyGraphql, map[string]*bintree{}},
 			"updateTask.graphql":          &bintree{_lgraphqlTasksUpdatetaskGraphql, map[string]*bintree{}},
+			"uploadFilesForTask.graphql":  &bintree{_lgraphqlTasksUploadfilesfortaskGraphql, map[string]*bintree{}},
 		}},
 		"usergroups": &bintree{nil, map[string]*bintree{
 			"addGroup.graphql":                &bintree{_lgraphqlUsergroupsAddgroupGraphql, map[string]*bintree{}},

--- a/api/lagoon/client/tasks.go
+++ b/api/lagoon/client/tasks.go
@@ -1,8 +1,17 @@
 package client
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
 
+	"github.com/uselagoon/machinery/api/lagoon/client/lgraphql"
 	"github.com/uselagoon/machinery/api/schema"
 )
 
@@ -42,4 +51,101 @@ func (c *Client) RunActiveStandbySwitch(ctx context.Context,
 	}{
 		Response: out,
 	})
+}
+
+// UploadFilesForTask uploads a file to a task.
+func (c *Client) UploadFilesForTask(ctx context.Context,
+	task int, files []string, out *schema.Task) error {
+
+	// uploading files via graphql is different, so this entire function is crafted specifically for uploading files
+	// it was built using the curl example from lagoon. this one supports multiple file uploads though
+	// machinebox graphql client doesn't support file uploads that conform to graphql spec, so this is custom compared to other query/mutations
+	// curl -sS "$TASK_API_HOST"/graphql \
+	// -H "Authorization: Bearer $TOKEN" \
+	// -F operations='{ "query": "mutation ($task: Int!, $files: [Upload!]!) { uploadFilesForTask(input:{task:$task, files:$files}) { id files { filename } } }", "variables": { "task": '"$TASK_DATA_ID"', "files": [null] } }' \
+	// -F map='{ "0": ["variables.files.0"] }' \
+	// -F 0=@$file.gz
+
+	form := new(bytes.Buffer)
+	writer := multipart.NewWriter(form)
+	formField, err := writer.CreateFormField("operations")
+	if err != nil {
+		return fmt.Errorf("couldn't create operations form field: %w", err)
+	}
+
+	// this asset is specific for this, it has to be one line if changes are made
+	q, err := lgraphql.Asset("_lgraphql/tasks/uploadFilesForTask.graphql")
+	if err != nil {
+		return fmt.Errorf("couldn't get graphql asset from assets: %w", err)
+	}
+	_, err = formField.Write([]byte(fmt.Sprintf("{ \"query\": \"%s\", \"variables\": { \"task\": %d, \"files\": [null] } }", string(q), task)))
+
+	formField, err = writer.CreateFormField("map")
+	if err != nil {
+		return fmt.Errorf("couldn't create upload map form field: %w", err)
+	}
+
+	// adding the files is done *after* the map formfield is written
+	fileMap := make(map[string][]string)
+	for idx := range files {
+		fileMap[fmt.Sprintf("%d", idx)] = append(fileMap[fmt.Sprintf("%d", idx)], fmt.Sprintf("variables.files.%d", idx))
+	}
+	ffmBytes, err := json.Marshal(fileMap)
+	if err != nil {
+		return fmt.Errorf("couldn't create upload map form field: %w", err)
+	}
+	_, err = formField.Write(ffmBytes)
+	for idx, file := range files {
+		fileMap[fmt.Sprintf("%d", idx)] = append(fileMap[fmt.Sprintf("%d", idx)], fmt.Sprintf("variables.files.%d", idx))
+
+		fw, err := writer.CreateFormFile(fmt.Sprintf("%d", idx), filepath.Base(file))
+		if err != nil {
+			return fmt.Errorf("couldn't read file %s: %w", file, err)
+		}
+		fd, err := os.Open(file)
+		if err != nil {
+			return fmt.Errorf("couldn't read file %s: %w", file, err)
+		}
+		defer fd.Close()
+		_, err = io.Copy(fw, fd)
+		if err != nil {
+			return fmt.Errorf("couldn't copy file %s: %w", file, err)
+		}
+	}
+
+	writer.Close()
+
+	client := &http.Client{}
+	req, err := http.NewRequest("POST", c.endpoint, form)
+	if err != nil {
+		return fmt.Errorf("couldn't create API request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+*c.token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("User-Agent", fmt.Sprintf("lagoon-client: %s", c.userAgent))
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("couldn't post file(s) to API: %w", err)
+	}
+	defer resp.Body.Close()
+	bodyText, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("couldn't read response from API: %w", err)
+	}
+
+	// unmarshal the response into a map
+	var respDat map[string]map[string]interface{}
+	err = json.Unmarshal([]byte(bodyText), &respDat)
+	if err != nil {
+		return fmt.Errorf("couldn't unmarshal response from API: %w", err)
+	}
+
+	// then extract our specific uploadFilesForTask data
+	b, _ := json.Marshal(respDat["data"]["uploadFilesForTask"])
+	err = json.Unmarshal([]byte(b), out)
+	if err != nil {
+		return fmt.Errorf("couldn't unmarshal response from API: %w", err)
+	}
+
+	return nil
 }

--- a/api/lagoon/tasks.go
+++ b/api/lagoon/tasks.go
@@ -13,6 +13,7 @@ type Tasks interface {
 	RunActiveStandbySwitch(ctx context.Context, project string, result *schema.Task) error
 	GetTaskByID(ctx context.Context, id int, result *schema.Task) error
 	UpdateTask(ctx context.Context, id int, patch schema.UpdateTaskPatchInput, result *schema.Task) error
+	UploadFilesForTask(ctx context.Context, id int, files []string, result *schema.Task) error
 }
 
 // ActiveStandbySwitch runs the activestandby switch.
@@ -31,4 +32,10 @@ func TaskByID(ctx context.Context, id int, t Tasks) (*schema.Task, error) {
 func UpdateTask(ctx context.Context, id int, patch schema.UpdateTaskPatchInput, t Tasks) (*schema.Task, error) {
 	result := schema.Task{}
 	return &result, t.UpdateTask(ctx, id, patch, &result)
+}
+
+// UploadFilesForTask updates a task.
+func UploadFilesForTask(ctx context.Context, id int, files []string, t Tasks) (*schema.Task, error) {
+	result := schema.Task{}
+	return &result, t.UploadFilesForTask(ctx, id, files, &result)
 }

--- a/api/schema/tasks.go
+++ b/api/schema/tasks.go
@@ -30,6 +30,11 @@ type Task struct {
 	RemoteID    string      `json:"remoteId,omitempty"`
 	Logs        string      `json:"logs,omitempty"`
 	Environment Environment `json:"environment,omitempty"`
+	Files       []Files     `json:"files,omitempty"`
+}
+
+type Files struct {
+	Filename string `json:"filename,omitempty"`
 }
 
 type ActiveStandbyResult struct {


### PR DESCRIPTION
Simple PR to add support for uploading files to tasks. This is useful to make it easier for tasks to upload files using the Lagoon CLI or some other tool.