### PR TITLE
Fix ProjectMetadata.Metadata type.

### DIFF
--- a/api/schema/project.go
+++ b/api/schema/project.go
@@ -90,7 +90,7 @@ type ProjectInput struct {
 // ProjectMetadata .
 type ProjectMetadata struct {
 	Project
-	Metadata string `json:"metadata"`
+	Metadata map[string]string `json:"metadata"`
 }
 
 type UpdateProjectPatchInput struct {


### PR DESCRIPTION
Fixes an issue with using `ProjectByNameMetadata()` where it always returned an unmarshaling error from the `encoding/json` package.