### PR TITLE
deprecate: environment storage bytesUsed for kiloBytesUsed

### DIFF
--- a/api/lagoon/client/_lgraphql/environments/addOrUpdateStorageOnEnvironment.graphql
+++ b/api/lagoon/client/_lgraphql/environments/addOrUpdateStorageOnEnvironment.graphql
@@ -1,0 +1,14 @@
+mutation (
+  $environment: Int!
+  $persistentStorageClaim: String!
+  $kibUsed: Float!
+  ) {
+    addOrUpdateEnvironmentStorage(input: {
+      environment: $environment
+      persistentStorageClaim: $persistentStorageClaim
+      kibUsed: $kibUsed
+    }
+  ){
+    id
+  }
+}

--- a/api/lagoon/client/client.go
+++ b/api/lagoon/client/client.go
@@ -3,8 +3,8 @@
 package client
 
 import (
-	"embed"
 	"context"
+	"embed"
 	"encoding/json"
 	"fmt"
 	"html/template"

--- a/api/lagoon/client/environments.go
+++ b/api/lagoon/client/environments.go
@@ -22,6 +22,20 @@ func (c *Client) UpdateEnvironmentStorage(ctx context.Context,
 	})
 }
 
+// UpdateStorageOnEnvironment updates an environments storage values.
+func (c *Client) UpdateStorageOnEnvironment(ctx context.Context,
+	in *schema.UpdateStorageOnEnvironmentInput, out *schema.UpdateStorageOnEnvironment) error {
+	req, err := c.newRequest("_lgraphql/environments/addOrUpdateStorageOnEnvironment.graphql", in)
+	if err != nil {
+		return err
+	}
+	return c.client.Run(ctx, req, &struct {
+		Response *schema.UpdateStorageOnEnvironment `json:"addOrUpdateStorageOnEnvironment"`
+	}{
+		Response: out,
+	})
+}
+
 // DeleteEnvironment deletes an environment.
 func (c *Client) DeleteEnvironment(ctx context.Context,
 	name, project string, execute bool, out *schema.DeleteEnvironment) error {

--- a/api/lagoon/environments.go
+++ b/api/lagoon/environments.go
@@ -13,6 +13,7 @@ type Environments interface {
 	BackupsForEnvironmentByName(context.Context, string, uint, *schema.Environment) error
 	AddRestore(context.Context, string, *schema.Restore) error
 	UpdateEnvironmentStorage(ctx context.Context, storage *schema.UpdateEnvironmentStorageInput, result *schema.UpdateEnvironmentStorage) error
+	UpdateStorageOnEnvironment(ctx context.Context, storage *schema.UpdateStorageOnEnvironmentInput, result *schema.UpdateStorageOnEnvironment) error
 	DeleteEnvironment(ctx context.Context, name, project string, execute bool, result *schema.DeleteEnvironment) error
 	UpdateEnvironment(ctx context.Context, id uint, patch schema.UpdateEnvironmentPatchInput, result *schema.Environment) error
 	SetEnvironmentServices(ctx context.Context, id uint, services []string, result *[]schema.EnvironmentService) error
@@ -41,6 +42,12 @@ func AddBackupRestore(ctx context.Context, backupID string, e Environments) (*sc
 func UpdateStorage(ctx context.Context, storage *schema.UpdateEnvironmentStorageInput, e Environments) (*schema.UpdateEnvironmentStorage, error) {
 	result := schema.UpdateEnvironmentStorage{}
 	return &result, e.UpdateEnvironmentStorage(ctx, storage, &result)
+}
+
+// UpdateStorage updates environment storage.
+func UpdateStorageOnEnvironment(ctx context.Context, storage *schema.UpdateStorageOnEnvironmentInput, e Environments) (*schema.UpdateStorageOnEnvironment, error) {
+	result := schema.UpdateStorageOnEnvironment{}
+	return &result, e.UpdateStorageOnEnvironment(ctx, storage, &result)
 }
 
 // DeleteEnvironment updates environment storage.

--- a/api/schema/environment.go
+++ b/api/schema/environment.go
@@ -86,6 +86,7 @@ type EnvironmentInput struct {
 }
 
 // UpdateEnvironmentStorageInput is used as the input for updating an environments storage.
+// @DEPRECATED
 type UpdateEnvironmentStorageInput struct {
 	Environment          int    `json:"environment"`
 	PersisteStorageClaim string `json:"persistentStorageClaim"`
@@ -93,7 +94,20 @@ type UpdateEnvironmentStorageInput struct {
 }
 
 // UpdateEnvironmentStorage is the response.
+// @DEPRECATED
 type UpdateEnvironmentStorage struct {
+	ID int `json:"id"`
+}
+
+// UpdateEnvironmentStorageInput is used as the input for updating an environments storage.
+type UpdateStorageOnEnvironmentInput struct {
+	Environment          int    `json:"environment"`
+	PersisteStorageClaim string `json:"persistentStorageClaim"`
+	KiBUsed              uint64 `json:"kibUsed"`
+}
+
+// UpdateEnvironmentStorage is the response.
+type UpdateStorageOnEnvironment struct {
 	ID int `json:"id"`
 }
 


### PR DESCRIPTION
Just marking the `bytesUsed` field as deprecated for now, `kibUsed` will be the new required input in the API in the future, but for now `bytesUsed` is still required by the API until the BC break is announced in a future release.