### PR TITLE
change: remove error from queries with no results

### DIFF
--- a/api/lagoon/client/deploytargets.go
+++ b/api/lagoon/client/deploytargets.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"github.com/machinebox/graphql"
 	"github.com/uselagoon/machinery/api/schema"
 )
@@ -97,9 +96,6 @@ func (c *Client) DeployTargetsByOrganizationNameOrID(ctx context.Context, name *
 		}
 	}
 
-	if len(o.DeployTargets) == 0 {
-		return fmt.Errorf("no deploy targets found for organization %s", o.Name)
-	}
 	data, err := json.Marshal(o.DeployTargets)
 	if err != nil {
 		return err

--- a/api/lagoon/client/environments.go
+++ b/api/lagoon/client/environments.go
@@ -3,8 +3,6 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-
 	"github.com/uselagoon/machinery/api/schema"
 )
 
@@ -115,9 +113,6 @@ func (c *Client) EnvironmentsByProjectName(ctx context.Context, project string, 
 	})
 	if err != nil {
 		return err
-	}
-	if len(p.Environments) == 0 {
-		return fmt.Errorf("no environments found for project")
 	}
 	db, err := json.Marshal(p.Environments)
 	if err != nil {

--- a/api/lagoon/client/projects.go
+++ b/api/lagoon/client/projects.go
@@ -3,8 +3,6 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-
 	"github.com/uselagoon/machinery/api/schema"
 )
 
@@ -223,9 +221,6 @@ func (c *Client) ProjectsByOrganizationID(ctx context.Context, id uint, projects
 	})
 	if err != nil {
 		return err
-	}
-	if len(o.Projects) == 0 {
-		return fmt.Errorf("no associated projects found for organization %s", o.Name)
 	}
 	data, err := json.Marshal(o.Projects)
 	if err != nil {

--- a/api/lagoon/client/usergroups.go
+++ b/api/lagoon/client/usergroups.go
@@ -3,8 +3,6 @@ package client
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-
 	"github.com/uselagoon/machinery/api/schema"
 )
 
@@ -308,9 +306,6 @@ func (c *Client) GroupsByOrganizationID(ctx context.Context, id uint, groups *[]
 	})
 	if err != nil {
 		return err
-	}
-	if len(o.Groups) == 0 {
-		return fmt.Errorf("no associated groups found for organization %s", o.Name)
 	}
 	data, err := json.Marshal(o.Groups)
 	if err != nil {


### PR DESCRIPTION
Currently an error is returned when no results are found on a number of queries. This removes the return statement to allow for the CLI to handle any zero results cases.

Required for https://github.com/uselagoon/lagoon-cli/pull/301