### PR TITLE
Feature: Adds build variables to deploys: branch, promote, and pull request

### DIFF
--- a/api/lagoon/client/_lgraphql/deployments/deployEnvironmentBranch.graphql
+++ b/api/lagoon/client/_lgraphql/deployments/deployEnvironmentBranch.graphql
@@ -2,7 +2,8 @@ mutation (
   $project: String!, 
   $branch: String!, 
   $branchRef: String,
-  $returnData: Boolean!) {
+  $returnData: Boolean!,
+  $buildVariables: [EnvKeyValueInput]) {
     deployEnvironmentBranch(input: {
       project:{
         name: $project
@@ -10,6 +11,7 @@ mutation (
       branchName: $branch
       branchRef: $branchRef
       returnData: $returnData
+      buildVariables: $buildVariables
     }
   )
 }

--- a/api/lagoon/client/_lgraphql/deployments/deployEnvironmentPromote.graphql
+++ b/api/lagoon/client/_lgraphql/deployments/deployEnvironmentPromote.graphql
@@ -2,7 +2,8 @@ mutation (
   $project: String!, 
   $sourceEnvironment: String!, 
   $destinationEnvironment: String!,
-  $returnData: Boolean!) {
+  $returnData: Boolean!,
+  $buildVariables: [EnvKeyValueInput]) {
     deployEnvironmentPromote(input:{
       sourceEnvironment:{
         name: $sourceEnvironment
@@ -15,6 +16,7 @@ mutation (
       }
       destinationEnvironment: $destinationEnvironment
       returnData: $returnData
+      buildVariables: $buildVariables
     }
   )
 }

--- a/api/lagoon/client/_lgraphql/deployments/deployEnvironmentPullrequest.graphql
+++ b/api/lagoon/client/_lgraphql/deployments/deployEnvironmentPullrequest.graphql
@@ -6,7 +6,8 @@ mutation (
   $baseBranchRef: String!,
   $headBranchName: String!,
   $headBranchRef: String!,
-  $returnData: Boolean!) {
+  $returnData: Boolean!,
+  $buildVariables: [EnvKeyValueInput]) {
     deployEnvironmentPullrequest(input: {
       project: $project
       number: $number
@@ -16,6 +17,7 @@ mutation (
       headBranchName: $headBranchName
       headBranchRef: $headBranchRef
       returnData: $returnData
+      buildVariables: $buildVariables
     }
   )
 }

--- a/api/schema/deployment.go
+++ b/api/schema/deployment.go
@@ -38,14 +38,15 @@ type DeployEnvironmentLatest struct {
 
 // DeployEnvironmentPullrequestInput is used as the input for deploying a pull request.
 type DeployEnvironmentPullrequestInput struct {
-	Project        ProjectInput `json:"project"`
-	Number         uint         `json:"number"`
-	Title          string       `json:"title"`
-	BaseBranchName string       `json:"baseBranchName"`
-	BaseBranchRef  string       `json:"baseBranchRef"`
-	HeadBranchName string       `json:"headBranchName"`
-	HeadBranchRef  string       `json:"headBranchRef"`
-	ReturnData     bool         `json:"returnData"`
+	Project        ProjectInput       `json:"project"`
+	Number         uint               `json:"number"`
+	Title          string             `json:"title"`
+	BaseBranchName string             `json:"baseBranchName"`
+	BaseBranchRef  string             `json:"baseBranchRef"`
+	HeadBranchName string             `json:"headBranchName"`
+	HeadBranchRef  string             `json:"headBranchRef"`
+	BuildVariables []EnvKeyValueInput `json:"buildVariables,omitempty"`
+	ReturnData     bool               `json:"returnData"`
 }
 
 // DeployEnvironmentPullrequest is the response.
@@ -55,10 +56,11 @@ type DeployEnvironmentPullrequest struct {
 
 // DeployEnvironmentBranchInput is used as the input for deploying a branch.
 type DeployEnvironmentBranchInput struct {
-	Project    string `json:"project"`
-	Branch     string `json:"branch"`
-	BranchRef  string `json:"branchRef"`
-	ReturnData bool   `json:"returnData"`
+	Project        string             `json:"project"`
+	Branch         string             `json:"branch"`
+	BranchRef      string             `json:"branchRef"`
+	BuildVariables []EnvKeyValueInput `json:"buildVariables,omitempty"`
+	ReturnData     bool               `json:"returnData"`
 }
 
 // DeployEnvironmentBranch is the response.
@@ -68,10 +70,11 @@ type DeployEnvironmentBranch struct {
 
 // DeployEnvironmentPromoteInput is used as the input for promoting one environment to another.
 type DeployEnvironmentPromoteInput struct {
-	Project                string `json:"project"`
-	SourceEnvironment      string `json:"sourceEnvironment"`
-	DestinationEnvironment string `json:"destinationEnvironment"`
-	ReturnData             bool   `json:"returnData"`
+	Project                string             `json:"project"`
+	SourceEnvironment      string             `json:"sourceEnvironment"`
+	DestinationEnvironment string             `json:"destinationEnvironment"`
+	BuildVariables         []EnvKeyValueInput `json:"buildVariables,omitempty"`
+	ReturnData             bool               `json:"returnData"`
 }
 
 // DeployEnvironmentPromote is the response.


### PR DESCRIPTION
This PR duplicates the logic for adding Build environment variables to deployments (branch, promote, and PR) in a similar fashion to what's currently [only](https://github.com/uselagoon/machinery/blob/v0.0.17/api/schema/deployment.go#L88) [found](https://github.com/uselagoon/machinery/blob/v0.0.17/api/lagoon/client/_lgraphql/deployments/deployEnvironmentLatest.graphql#L6) in the "deploy environment latest" API.

It simply enhances the mutations and the input structures.