### PR TITLE
fix: remove close button from cli opener as it doesnt always work

### DIFF
--- a/utils/auth/html/response.html
+++ b/utils/auth/html/response.html
@@ -105,15 +105,7 @@ body, html {
 		<div id="kc-content-wrapper" class="kc-content-wrapper">
 			<h1>Login successful</h1>
 			<p>You can close this window and return to the Lagoon CLI.</p>
-            <div id="kc-form-buttons" class="">
-                <button tabindex="4" class="" name="login" id="kc-login" type="button" onclick="closeWindow();">Close</button>
-            </div>
 		</div>
 	<div class="background"></div>
-	<script>
-		function closeWindow() {
-			window.open("", '_self').window.close();
-		}
-	</script>
 </body>
 </html>


### PR DESCRIPTION
The `close` button doesn't always close the tab due to browser security. This just simply removes the button and closing the browser tab or window is left to the user to perform. Sorry :'( 