### PR TITLE
feat: add versioned requests to support changing schemas where possible

### DIFF
--- a/api/lagoon/client/_lgraphql/environments/environmentById.graphql
+++ b/api/lagoon/client/_lgraphql/environments/environmentById.graphql
@@ -17,12 +17,14 @@ query (
     services{
       id
       name
+      {{ if apiVerGreaterThanOrEqual . "2.18.0" }}
       type
       containers{
         name
       }
       created
       updated
+      {{ end }}
     }
   }
 }

--- a/api/lagoon/client/_lgraphql/environments/environmentByName.graphql
+++ b/api/lagoon/client/_lgraphql/environments/environmentByName.graphql
@@ -19,12 +19,14 @@ query (
     services{
       id
       name
+      {{ if apiVerGreaterThanOrEqual . "2.18.0" }}
       type
       containers{
         name
       }
       created
       updated
+      {{ end }}
     }
   }
 }

--- a/api/lagoon/client/_lgraphql/environments/environmentByNamespace.graphql
+++ b/api/lagoon/client/_lgraphql/environments/environmentByNamespace.graphql
@@ -17,12 +17,14 @@ query (
     services{
       id
       name
+      {{ if apiVerGreaterThanOrEqual . "2.18.0" }}
       type
       containers{
         name
       }
       created
       updated
+      {{ end }}
     }
   }
 }

--- a/api/lagoon/client/_lgraphql/environments/environmentsByProjectName.graphql
+++ b/api/lagoon/client/_lgraphql/environments/environmentsByProjectName.graphql
@@ -28,12 +28,14 @@ query (
         services{
           id
           name
+          {{ if apiVerGreaterThanOrEqual . "2.18.0" }}
           type
           containers{
             name
           }
           created
           updated
+          {{ end }}
         }
       }
     }

--- a/api/lagoon/client/_lgraphql/environments/updateEnvironment.graphql
+++ b/api/lagoon/client/_lgraphql/environments/updateEnvironment.graphql
@@ -20,12 +20,14 @@ mutation (
         services{
             id
             name
+            {{ if apiVerGreaterThanOrEqual . "2.18.0" }}
             type
             containers{
                 name
             }
             created
             updated
+            {{ end }}
         }
     }
 }

--- a/api/lagoon/client/environments.go
+++ b/api/lagoon/client/environments.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/uselagoon/machinery/api/schema"
 )
 
@@ -54,7 +55,7 @@ func (c *Client) DeleteEnvironment(ctx context.Context,
 func (c *Client) EnvironmentByName(ctx context.Context, name string,
 	projectID uint, environment *schema.Environment) error {
 
-	req, err := c.newRequest("_lgraphql/environments/environmentByName.graphql",
+	req, err := c.newVersionedRequest("_lgraphql/environments/environmentByName.graphql",
 		map[string]interface{}{
 			"name":    name,
 			"project": projectID,
@@ -73,7 +74,7 @@ func (c *Client) EnvironmentByName(ctx context.Context, name string,
 // EnvironmentByID queries the Lagoon API for an environment by its ID and unmarshals the response into environment.
 func (c *Client) EnvironmentByID(ctx context.Context, environmentID uint, environment *schema.Environment) error {
 
-	req, err := c.newRequest("_lgraphql/environments/environmentById.graphql",
+	req, err := c.newVersionedRequest("_lgraphql/environments/environmentById.graphql",
 		map[string]interface{}{
 			"id": environmentID,
 		})
@@ -92,7 +93,7 @@ func (c *Client) EnvironmentByID(ctx context.Context, environmentID uint, enviro
 // and unmarshals the response into environment.
 func (c *Client) EnvironmentByNamespace(ctx context.Context, namespace string, environment *schema.Environment) error {
 
-	req, err := c.newRequest("_lgraphql/environments/environmentByNamespace.graphql",
+	req, err := c.newVersionedRequest("_lgraphql/environments/environmentByNamespace.graphql",
 		map[string]interface{}{
 			"namespace": namespace,
 		})
@@ -111,7 +112,7 @@ func (c *Client) EnvironmentByNamespace(ctx context.Context, namespace string, e
 // and unmarshals the response into environment.
 func (c *Client) EnvironmentsByProjectName(ctx context.Context, project string, environments *[]schema.Environment) error {
 
-	req, err := c.newRequest("_lgraphql/environments/environmentsByProjectName.graphql",
+	req, err := c.newVersionedRequest("_lgraphql/environments/environmentsByProjectName.graphql",
 		map[string]interface{}{
 			"project": project,
 		})
@@ -192,7 +193,7 @@ func (c *Client) AddOrUpdateEnvironment(ctx context.Context,
 func (c *Client) UpdateEnvironment(
 	ctx context.Context, id uint, patch schema.UpdateEnvironmentPatchInput, environment *schema.Environment) error {
 
-	req, err := c.newRequest("_lgraphql/environments/updateEnvironment.graphql",
+	req, err := c.newVersionedRequest("_lgraphql/environments/updateEnvironment.graphql",
 		map[string]interface{}{
 			"id":    id,
 			"patch": patch,

--- a/api/lagoon/client/mutation_test.go
+++ b/api/lagoon/client/mutation_test.go
@@ -57,7 +57,7 @@ func TestAddProjectRequest(t *testing.T) {
 				}))
 			defer ts.Close()
 			token := ""
-			c := client.New(ts.URL, "", &token, false)
+			c := client.New(ts.URL, "", "v0.0.0", &token, false)
 			// ignore response error - we're testing the request
 			_ = c.AddProject(context.Background(), &schema.AddProjectInput{
 				Name:                  "foo",
@@ -112,7 +112,7 @@ func TestAddUser(t *testing.T) {
 				}))
 			defer ts.Close()
 			token := ""
-			c := client.New(ts.URL, "", &token, false)
+			c := client.New(ts.URL, "", "v0.0.0", &token, false)
 
 			out := schema.User{}
 			err := c.AddUser(context.Background(), tc.input.in, &out)


### PR DESCRIPTION
Just adding versioned requests to allow for times where the schema may add new return fields that aren't available in older versions.

This does change the `New` constructor to require a version of the API to be provided

example: https://github.com/uselagoon/lagoon-cli/pull/335