### PR TITLE
fix: use the right mutation for the new storage update

### DIFF
--- a/api/lagoon/client/_lgraphql/environments/addOrUpdateStorageOnEnvironment.graphql
+++ b/api/lagoon/client/_lgraphql/environments/addOrUpdateStorageOnEnvironment.graphql
@@ -3,7 +3,7 @@ mutation (
   $persistentStorageClaim: String!
   $kibUsed: Float!
   ) {
-    addOrUpdateEnvironmentStorage(input: {
+    addOrUpdateStorageOnEnvironment(input: {
       environment: $environment
       persistentStorageClaim: $persistentStorageClaim
       kibUsed: $kibUsed


### PR DESCRIPTION
Fixes a bug in the mutation for `addOrUpdateStorageOnEnvironment` to use the right mutation name