### PR TITLE
fix: negate organization id check

### DIFF
--- a/api/lagoon/client/notification.go
+++ b/api/lagoon/client/notification.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+
 	"github.com/machinebox/graphql"
 	"github.com/uselagoon/machinery/api/schema"
 )
@@ -15,7 +16,7 @@ func (c *Client) AddNotificationSlack(ctx context.Context, in *schema.AddNotific
 		"webhook": in.Webhook,
 		"channel": in.Channel,
 	}
-	if *in.Organization == 0 {
+	if *in.Organization != 0 {
 		variables["organization"] = in.Organization
 	}
 	req, err = c.newRequest("_lgraphql/notifications/addNotificationSlack.graphql", variables)
@@ -39,7 +40,7 @@ func (c *Client) AddNotificationRocketChat(ctx context.Context, in *schema.AddNo
 		"webhook": in.Webhook,
 		"channel": in.Channel,
 	}
-	if *in.Organization == 0 {
+	if *in.Organization != 0 {
 		variables["organization"] = in.Organization
 	}
 	req, err = c.newRequest("_lgraphql/notifications/addNotificationRocketChat.graphql", variables)
@@ -62,7 +63,7 @@ func (c *Client) AddNotificationEmail(ctx context.Context, in *schema.AddNotific
 		"name":         in.Name,
 		"emailAddress": in.EmailAddress,
 	}
-	if *in.Organization == 0 {
+	if *in.Organization != 0 {
 		variables["organization"] = in.Organization
 	}
 	req, err = c.newRequest("_lgraphql/notifications/addNotificationEmail.graphql", variables)
@@ -85,7 +86,7 @@ func (c *Client) AddNotificationMicrosoftTeams(ctx context.Context, in *schema.A
 		"name":    in.Name,
 		"webhook": in.Webhook,
 	}
-	if *in.Organization == 0 {
+	if *in.Organization != 0 {
 		variables["organization"] = in.Organization
 	}
 	req, err = c.newRequest("_lgraphql/notifications/addNotificationMicrosoftTeams.graphql", variables)
@@ -108,7 +109,7 @@ func (c *Client) AddNotificationWebhook(ctx context.Context, in *schema.AddNotif
 		"name":    in.Name,
 		"webhook": in.Webhook,
 	}
-	if *in.Organization == 0 {
+	if *in.Organization != 0 {
 		variables["organization"] = in.Organization
 	}
 	req, err = c.newRequest("_lgraphql/notifications/addNotificationWebhook.graphql", variables)


### PR DESCRIPTION
Just a quick one to fix the check for the organization id. Previously it was adding the organization field to the mutation if it was 0, but it should only do this if it is not 0