### PR TITLE
Feat: Adds GetEnvVariablesByProjectEnvironmentName & GetProjectKeyByName

### DIFF
--- a/api/lagoon/client/_lgraphql/projects/projectKeyByName.graphql
+++ b/api/lagoon/client/_lgraphql/projects/projectKeyByName.graphql
@@ -1,0 +1,7 @@
+query (
+  $name: String!) {
+  projectByName(
+    name: $name) {
+    publicKey
+  }
+}

--- a/api/lagoon/client/_lgraphql/projects/projectKeyByNameRevealed.graphql
+++ b/api/lagoon/client/_lgraphql/projects/projectKeyByNameRevealed.graphql
@@ -1,0 +1,8 @@
+query (
+  $name: String!) {
+  projectByName(
+    name: $name) {
+    privateKey
+    publicKey
+  }
+}

--- a/api/lagoon/client/_lgraphql/variables/getEnvVariablesByProjectEnvironmentName.graphql
+++ b/api/lagoon/client/_lgraphql/variables/getEnvVariablesByProjectEnvironmentName.graphql
@@ -1,0 +1,10 @@
+query (
+  $input: EnvVariableByProjectEnvironmentNameInput!
+){
+  getEnvVariablesByProjectEnvironmentName(input: $input) {
+    id
+    name
+    value
+    scope
+  }
+}

--- a/api/lagoon/client/projects.go
+++ b/api/lagoon/client/projects.go
@@ -242,3 +242,24 @@ func (c *Client) RemoveProjectFromOrganization(ctx context.Context, in *schema.R
 		Response: out,
 	})
 }
+
+// ProjectKeyByName queries the Lagoon API for a project by its name, and returns the public key & optionally the private key.
+func (c *Client) ProjectKeyByName(ctx context.Context, name string, revealValue bool, project *schema.Project) error {
+	query := "_lgraphql/projects/projectKeyByName.graphql"
+	if revealValue {
+		query = "_lgraphql/projects/projectKeyByNameRevealed.graphql"
+	}
+	req, err := c.newRequest(query,
+		map[string]interface{}{
+			"name": name,
+		})
+	if err != nil {
+		return err
+	}
+
+	return c.client.Run(ctx, req, &struct {
+		Response *schema.Project `json:"projectByName"`
+	}{
+		Response: project,
+	})
+}

--- a/api/lagoon/client/variables.go
+++ b/api/lagoon/client/variables.go
@@ -1,0 +1,25 @@
+package client
+
+import (
+	"context"
+	"github.com/uselagoon/machinery/api/schema"
+)
+
+// EnvVariablesByProjectEnvironmentName queries the Lagoon API for a envvars by project environment and unmarshals the response.
+func (c *Client) EnvVariablesByProjectEnvironmentName(
+	ctx context.Context, in *schema.EnvVariableByProjectEnvironmentNameInput, envkeyvalue *[]schema.EnvKeyValue) error {
+
+	req, err := c.newRequest("_lgraphql/variables/getEnvVariablesByProjectEnvironmentName.graphql",
+		map[string]interface{}{
+			"input": in,
+		})
+	if err != nil {
+		return err
+	}
+
+	return c.client.Run(ctx, req, &struct {
+		Response *[]schema.EnvKeyValue `json:"getEnvVariablesByProjectEnvironmentName"`
+	}{
+		Response: envkeyvalue,
+	})
+}

--- a/api/lagoon/projects.go
+++ b/api/lagoon/projects.go
@@ -22,6 +22,7 @@ type Projects interface {
 	ProjectByNameExtended(ctx context.Context, name string, project *schema.Project) error
 	ProjectsByOrganizationID(ctx context.Context, name uint, project *[]schema.OrgProject) error
 	RemoveProjectFromOrganization(ctx context.Context, in *schema.RemoveProjectFromOrganizationInput, out *schema.Project) error
+	ProjectKeyByName(ctx context.Context, name string, revealValue bool, project *schema.Project) error
 }
 
 // GetMinimalProjectByName gets info of projects in lagoon that have matching metadata.
@@ -94,4 +95,10 @@ func ListProjectsByOrganizationID(ctx context.Context, id uint, p Projects) (*[]
 func RemoveProjectFromOrganization(ctx context.Context, in *schema.RemoveProjectFromOrganizationInput, out Projects) (*schema.Project, error) {
 	response := schema.Project{}
 	return &response, out.RemoveProjectFromOrganization(ctx, in, &response)
+}
+
+// GetProjectKeyByName gets the project keys of a project in Lagoon.
+func GetProjectKeyByName(ctx context.Context, name string, revealValue bool, p Projects) (*schema.Project, error) {
+	project := schema.Project{}
+	return &project, p.ProjectKeyByName(ctx, name, revealValue, &project)
 }

--- a/api/lagoon/variables.go
+++ b/api/lagoon/variables.go
@@ -1,0 +1,18 @@
+// Package lagoon implements high-level functions for interacting with the
+// Lagoon API.
+package lagoon
+
+import (
+	"context"
+	"github.com/uselagoon/machinery/api/schema"
+)
+
+type Variables interface {
+	EnvVariablesByProjectEnvironmentName(ctx context.Context, in *schema.EnvVariableByProjectEnvironmentNameInput, envvar *[]schema.EnvKeyValue) error
+}
+
+// GetEnvVariablesByProjectEnvironmentName lists variables given a project/environment.
+func GetEnvVariablesByProjectEnvironmentName(ctx context.Context, in *schema.EnvVariableByProjectEnvironmentNameInput, v Variables) (*[]schema.EnvKeyValue, error) {
+	envvar := []schema.EnvKeyValue{}
+	return &envvar, v.EnvVariablesByProjectEnvironmentName(ctx, in, &envvar)
+}

--- a/api/schema/env_variables.go
+++ b/api/schema/env_variables.go
@@ -41,3 +41,8 @@ type EnvKeyValueInput struct {
 	Name  string `json:"name,omitempty"`
 	Value string `json:"value,omitempty"`
 }
+
+type EnvVariableByProjectEnvironmentNameInput struct {
+	Environment string `json:"environment,omitempty"`
+	Project     string `json:"project"`
+}

--- a/api/schema/project.go
+++ b/api/schema/project.go
@@ -31,6 +31,7 @@ type AddProjectInput struct {
 	StorageCalc                  uint   `json:"storageCalc"`
 	DevelopmentEnvironmentsLimit uint   `json:"developmentEnvironmentsLimit,omitempty"`
 	PrivateKey                   string `json:"privateKey,omitempty"`
+	PublicKey                    string `json:"publicKey,omitempty"`
 	BuildImage                   string `json:"buildImage,omitempty"`
 	Organization                 uint   `json:"organization,omitempty"`
 	AddOrgOwner                  bool   `json:"addOrgOwner,omitempty"`


### PR DESCRIPTION
Adds `GetEnvVariablesByProjectEnvironmentName` & `GetProjectKeyByName` required for https://github.com/uselagoon/lagoon-cli/pull/345


Companion PR to  https://github.com/uselagoon/lagoon-cli/pull/345