### PR TITLE
chore: add deletebackup mutation support

### DIFF
--- a/api/lagoon/client/_lgraphql/environments/deleteBackup.graphql
+++ b/api/lagoon/client/_lgraphql/environments/deleteBackup.graphql
@@ -1,0 +1,5 @@
+mutation ($backupId: String!) {
+	deleteBackup(input: {
+		backupId: $backupId
+	})
+}

--- a/api/lagoon/client/environments.go
+++ b/api/lagoon/client/environments.go
@@ -285,3 +285,21 @@ func (c *Client) DeleteEnvironmentService(
 		Response: result,
 	})
 }
+
+// DeleteBackup deletes an environment backup.
+func (c *Client) DeleteBackup(ctx context.Context,
+	backupID string, result *schema.DeleteBackup) error {
+	req, err := c.newRequest("_lgraphql/environments/deleteBackup.graphql",
+		map[string]interface{}{
+			"backupId": backupID,
+		})
+	if err != nil {
+		return err
+	}
+
+	return c.client.Run(ctx, req, &struct {
+		Response *schema.DeleteBackup `json:"deleteBackup"`
+	}{
+		Response: result,
+	})
+}

--- a/api/lagoon/environments.go
+++ b/api/lagoon/environments.go
@@ -24,6 +24,7 @@ type Environments interface {
 	SSHEndpointByNamespace(ctx context.Context, namespace string, result *schema.Environment) error
 	AddOrUpdateEnvironmentService(ctx context.Context, service schema.AddEnvironmentServiceInput, result *schema.EnvironmentService) error
 	DeleteEnvironmentService(ctx context.Context, service schema.DeleteEnvironmentServiceInput, result *schema.DeleteEnvironmentService) error
+	DeleteBackup(context.Context, string, *schema.DeleteBackup) error
 }
 
 // GetBackupsForEnvironmentByName gets backup info in lagoon for specific environment.
@@ -108,4 +109,10 @@ func AddOrUpdateEnvironmentService(ctx context.Context, service schema.AddEnviro
 func DeleteEnvironmentService(ctx context.Context, service schema.DeleteEnvironmentServiceInput, e Environments) (*schema.DeleteEnvironmentService, error) {
 	result := schema.DeleteEnvironmentService{}
 	return &result, e.DeleteEnvironmentService(ctx, service, &result)
+}
+
+// DeleteBackup deletes an environment backup.
+func DeleteBackup(ctx context.Context, backupID string, e Environments) (*schema.DeleteBackup, error) {
+	result := schema.DeleteBackup{}
+	return &result, e.DeleteBackup(ctx, backupID, &result)
 }

--- a/api/schema/backups.go
+++ b/api/schema/backups.go
@@ -29,3 +29,8 @@ type AddRestoreInput struct {
 	RestoreLocation string `json:"restoreLocation"`
 	Execute         bool   `json:"execute"`
 }
+
+// DeleteBackup is the response.
+type DeleteBackup struct {
+	DeleteBackup string `json:"deleteBackup"`
+}


### PR DESCRIPTION
Just a quick one that allows the `backup-handler` in lagoon to be updated to use machinery