### PR TITLE
feat: support for organization admins and adjustments to users

### DIFF
--- a/api/lagoon/client/_lgraphql/organizations/listOrganizationAdminsByName.graphql
+++ b/api/lagoon/client/_lgraphql/organizations/listOrganizationAdminsByName.graphql
@@ -10,6 +10,7 @@ query (
         firstName
         lastName
         owner
+        admin
       }
     }
 }

--- a/api/lagoon/client/_lgraphql/usergroups/addAdminToOrganization.graphql
+++ b/api/lagoon/client/_lgraphql/usergroups/addAdminToOrganization.graphql
@@ -1,11 +1,13 @@
 mutation (
   $user: UserInput!,
   $organization: Int!,
-  $owner: Boolean) {
+  $owner: Boolean,
+  $admin: Boolean) {
     addUserToOrganization(input: {
       user: $user
       organization: $organization
       owner: $owner
+      admin: $admin
     }) {
       id
       name

--- a/api/lagoon/client/_lgraphql/usergroups/usersByOrganization.graphql
+++ b/api/lagoon/client/_lgraphql/usergroups/usersByOrganization.graphql
@@ -7,6 +7,7 @@ query (
     firstName
     lastName
     owner
+    admin
     comment
   }
 }

--- a/api/schema/organization.go
+++ b/api/schema/organization.go
@@ -92,6 +92,7 @@ type OrgUser struct {
 	LastName   string       `json:"lastName,omitempty"`
 	Comment    string       `json:"comment,omitempty"`
 	Owner      bool         `json:"owner,omitempty"`
+	Admin      bool         `json:"admin,omitempty"`
 	GroupRoles []GroupRoles `json:"groupRoles,omitempty"`
 }
 

--- a/api/schema/user.go
+++ b/api/schema/user.go
@@ -40,6 +40,7 @@ type AddUserToOrganizationInput struct {
 	User         UserInput `json:"user"`
 	Organization uint      `json:"organization"`
 	Owner        bool      `json:"owner,omitempty"`
+	Admin        bool      `json:"admin,omitempty"`
 }
 
 type DeleteUserInput struct {


### PR DESCRIPTION
This adds a new command to list the administrators of an organization only.

Additionally, changes made to the `UsersByOrganization` to renamed `UsersByOrganizationID` and then a new `UsersByOrganizationName` which performs an organization name query first, then calls the `ID` query.

This makes it easier for tools to consume without having to do the double logic step that is currently done in the tools themselves. We could probably change more things that use `ID` as an input to do this (and still retain the `ID` versions). 

From an API side thing though in `uselagoon/lagoon` core, anywhere that `id` or `name` can be used to interact with something, we should definitely support both inputs where possible/makes sense in the future, and we can do this with deprecation or introduction of new resolvers.