### PR TITLE
feat: add cron utility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/adrg/xdg v0.4.0
+	github.com/cxmcc/unixsums v0.0.0-20131125091133-89564297d82f
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
 github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
+github.com/cxmcc/unixsums v0.0.0-20131125091133-89564297d82f h1:PkAFGgVtJnasAxOaiEY1RYPx8W+7X7l66vi8T2apKCM=
+github.com/cxmcc/unixsums v0.0.0-20131125091133-89564297d82f/go.mod h1:XJq7OckzkOtlgeEKFwkH2gFbc1+1WRFUBf7QnvfyrzQ=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=

--- a/utils/cron/cron.go
+++ b/utils/cron/cron.go
@@ -1,0 +1,287 @@
+package cron
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/cxmcc/unixsums/cksum"
+)
+
+func ConvertCrontab(namespace, cron string) (string, error) {
+	// Seed is used to generate pseudo random numbers. The seed is based on the
+	// namespace, so will not change after a deployment for a given namespace.
+	seed := cksum.Cksum([]byte(fmt.Sprintf("%s\n", namespace)))
+	var minutes, hours, days, months, dayweek string
+	splitCron := strings.Split(strings.Trim(cron, " "), " ")
+	// check the provided cron splits into 5
+	if len(splitCron) == 5 {
+		for idx, val := range splitCron {
+			if idx == 0 {
+				match1 := regexp.MustCompile(`^(M|H)$`).MatchString(val)
+				if match1 {
+					// If just an `M` or `H` (for backwards compatibility) is defined, we
+					// generate a pseudo random minute.
+					minutes = strconv.Itoa(int(math.Mod(float64(seed), 60)))
+					continue
+				}
+				match2 := regexp.MustCompile(`^(M|H|\*)/([0-5]?[0-9])$`).MatchString(val)
+				if match2 {
+					// A Minute like M/15 (or H/15 or */15 for backwards compatibility) is defined, create a list of minutes with a random start
+					// like 4,19,34,49 or 6,21,36,51
+					params := getCaptureBlocks(`^(?P<P1>M|H|\*)/(?P<P2>[0-5]?[0-9])$`, val)
+					step, err := strconv.Atoi(params["P2"])
+					if err != nil {
+						return "", fmt.Errorf("cron definition '%s' is invalid, unable to determine minutes value", cron)
+					}
+					counter := int(math.Mod(float64(seed), float64(step)))
+					var minutesArr []string
+					for counter < 60 {
+						minutesArr = append(minutesArr, fmt.Sprintf("%d", counter))
+						counter += step
+					}
+					minutes = strings.Join(minutesArr, ",")
+					continue
+				}
+				if isInCSVRange(val, 0, 59) {
+					// A minute like 0,10,15,30,59
+					minutes = val
+					continue
+				}
+				if isInRange(val, 0, 59) {
+					// A minute like 0-59
+					minutes = val
+					continue
+				}
+				if val == "*" {
+					// otherwise pass the * through
+					minutes = val
+					continue
+				}
+				// if the value is not valid, return an error with where the issue is
+				if minutes == "" {
+					return "", fmt.Errorf("cron definition '%s' is invalid, unable to determine minutes value", cron)
+				}
+			}
+			if idx == 1 {
+				match1 := regexp.MustCompile(`^H$`).MatchString(val)
+				if match1 {
+					// If just an `H` is defined, we generate a pseudo random hour.
+					hours = strconv.Itoa(int(math.Mod(float64(seed), 24)))
+					continue
+				}
+				match2 := regexp.MustCompile(`^H\(([01]?[0-9]|2[0-3])-([01]?[0-9]|2[0-3])\)$`).MatchString(val)
+				if match2 {
+					// If H is defined with a given range, example: H(2-4), we generate a random hour between 2-4
+					params := getCaptureBlocks(`^H\((?P<P1>[01]?[0-9]|2[0-3])-(?P<P2>[01]?[0-9]|2[0-3])\)$`, val)
+					hFrom, err := strconv.Atoi(params["P1"])
+					if err != nil {
+						return "", fmt.Errorf("cron definition '%s' is invalid, unable to determine hours value", cron)
+					}
+					hTo, err := strconv.Atoi(params["P2"])
+					if err != nil {
+						return "", fmt.Errorf("cron definition '%s' is invalid, unable to determine hours value", cron)
+					}
+					if hFrom < hTo {
+						// Example: HOUR_FROM: 2, HOUR_TO: 4
+						// Calculate the difference between the two hours (in example will be 2)
+						maxDiff := float64(hTo - hFrom)
+						// Generate a difference based on the SEED (in example will be 0, 1 or 2)
+						diff := int(math.Mod(float64(seed), maxDiff))
+						// Add the generated difference to the FROM hour (in example will be 2, 3 or 4)
+						hours = strconv.Itoa(hFrom + diff)
+						continue
+					}
+					if hFrom > hTo {
+						// If the FROM is larger than the TO, we have a range like 22-2
+						// Calculate the difference between the two hours with a 24 hour jump (in example will be 4)
+						maxDiff := float64(24 - hFrom + hTo)
+						// Generate a difference based on the SEED (in example will be 0, 1, 2, 3 or 4)
+						diff := int(math.Mod(float64(seed), maxDiff))
+						// Add the generated difference to the FROM hour (in example will be 22, 23, 24, 25 or 26)
+						if hFrom+diff >= 24 {
+							// If the hour is higher than 24, we subtract 24 to handle the midnight change
+							hours = strconv.Itoa(hFrom + diff - 24)
+							continue
+						}
+						hours = strconv.Itoa(hFrom + diff)
+						continue
+					}
+					if hFrom == hTo {
+						hours = strconv.Itoa(hFrom)
+						continue
+					}
+				}
+				match3 := regexp.MustCompile(`^(H|\*)/([01]?[0-9]|2[0-3])$`).MatchString(val)
+				if match3 {
+					// An hour like H/15 or */15 is defined, create a list of hours with a random start
+					// like 1,7,13,19
+					params := getCaptureBlocks(`^(?P<P1>H|\*)/(?P<P2>[01]?[0-9]|2[0-3])$`, val)
+					step, err := strconv.Atoi(params["P2"])
+					if err != nil {
+						return "", fmt.Errorf("cron definition '%s' is invalid, unable to determine hours value", cron)
+					}
+					counter := int(math.Mod(float64(seed), float64(step)))
+					var hoursArr []string
+					for counter < 24 {
+						hoursArr = append(hoursArr, fmt.Sprintf("%d", counter))
+						counter += step
+					}
+					hours = strings.Join(hoursArr, ",")
+					continue
+				}
+				if isInCSVRange(val, 0, 23) {
+					hours = val
+					continue
+				}
+				if isInRange(val, 0, 23) {
+					hours = val
+					continue
+				}
+				if val == "*" {
+					hours = val
+					continue
+				}
+				// if the value is not valid, return an error with where the issue is
+				if hours == "" {
+					return "", fmt.Errorf("cron definition '%s' is invalid, unable to determine hours value", cron)
+				}
+			}
+			if idx == 2 {
+				if isInCSVRange(val, 1, 31) {
+					days = val
+					continue
+				}
+				if isInRange(val, 1, 31) {
+					days = val
+					continue
+				}
+				if val == "*" {
+					days = val
+					continue
+				}
+				// if the value is not valid, return an error with where the issue is
+				if days == "" {
+					return "", fmt.Errorf("cron definition '%s' is invalid, unable to determine days value", cron)
+				}
+			}
+			if idx == 3 {
+				if isInCSVRange(val, 1, 12) {
+					months = val
+					continue
+				}
+				if isInRange(val, 1, 12) {
+					months = val
+					continue
+				}
+				if val == "*" {
+					months = val
+					continue
+				}
+				if isMonth(val) {
+					months = val
+					continue
+				}
+				// if the value is not valid, return an error with where the issue is
+				if months == "" {
+					return "", fmt.Errorf("cron definition '%s' is invalid, unable to determine months value", cron)
+				}
+			}
+			if idx == 4 {
+				if isInCSVRange(val, 0, 6) {
+					dayweek = val
+					continue
+				}
+				if isInRange(val, 0, 6) {
+					dayweek = val
+					continue
+				}
+				if val == "*" {
+					dayweek = val
+					continue
+				}
+				if isDayOfWeek(val) {
+					dayweek = val
+					continue
+				}
+				// if the value is not valid, return an error with where the issue is
+				if dayweek == "" {
+					return "", fmt.Errorf("cron definition '%s' is invalid, unable to determine day(week) value", cron)
+				}
+			}
+		}
+		return fmt.Sprintf("%v %v %v %v %v", minutes, hours, days, months, dayweek), nil
+	}
+	if len(splitCron) < 5 && len(splitCron) > 0 || len(splitCron) > 5 {
+		return "", fmt.Errorf("cron definition '%s' is invalid, %d fields provided, required 5", cron, len(splitCron))
+	}
+	return "", fmt.Errorf("cron definition '%s' is invalid", cron)
+}
+
+func getCaptureBlocks(regex, val string) (captureMap map[string]string) {
+	var regexComp = regexp.MustCompile(regex)
+	match := regexComp.FindStringSubmatch(val)
+	captureMap = make(map[string]string)
+	for i, name := range regexComp.SubexpNames() {
+		if i > 0 && i <= len(match) {
+			captureMap[name] = match[i]
+		}
+	}
+	return captureMap
+}
+
+// check if the provided cron time definition is a valid `1,2,4,8` type range
+func isInCSVRange(s string, min, max int) bool {
+	items := strings.Split(s, ",")
+	for _, val := range items {
+		num, err := strconv.Atoi(val)
+		if err != nil {
+			// not a number, return false
+			return false
+		}
+		if num < min || num > max {
+			// outside range, return false
+			return false
+		}
+	}
+	return true
+}
+
+// check if the provided cron day string is a valid
+func isDayOfWeek(s string) bool {
+	days := []string{"SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"}
+	return slices.Contains(days, strings.ToUpper(s))
+}
+
+// check if the provided cron month string is a valid
+func isMonth(s string) bool {
+	days := []string{"JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"}
+	return slices.Contains(days, strings.ToUpper(s))
+}
+
+// check if the provided cron time definition is a valid `1-2` type range
+func isInRange(s string, min, max int) bool {
+	items := strings.Split(s, "-")
+	if len(items) > 2 || len(items) < 1 {
+		// too  many or not enough items split by -
+		return false
+	}
+	hFrom, err := strconv.Atoi(items[0])
+	if err != nil {
+		// not a number or error checking if it is, return false
+		return false
+	}
+	hTo, err := strconv.Atoi(items[1])
+	if err != nil {
+		// not a number or error checking if it is, return false
+		return false
+	}
+	if hFrom > hTo || hFrom < min || hFrom > max || hTo < min || hTo > max {
+		// numbers in range are not in valid format of LOW-HIGH
+		return false
+	}
+	return true
+}

--- a/utils/cron/cron_test.go
+++ b/utils/cron/cron_test.go
@@ -1,0 +1,215 @@
+package cron
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConvertCrontab(t *testing.T) {
+	type args struct {
+		namespace string
+		cron      string
+	}
+	tests := []struct {
+		name       string
+		args       args
+		want       string
+		wantErrMsg string
+		wantErr    bool
+	}{
+		{
+			name: "test1",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "M * * * *",
+			},
+			want: "31 * * * *",
+		},
+		{
+			name: "test2",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "M/5 * * * *",
+			},
+			want: "1,6,11,16,21,26,31,36,41,46,51,56 * * * *",
+		},
+		{
+			name: "test3",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "M H(2-4) * * *",
+			},
+			want: "31 3 * * *",
+		},
+		{
+			name: "test4",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "M H(22-2) * * *",
+			},
+			want: "31 1 * * *",
+		},
+		{
+			name: "test5",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "M/15 H(22-2) * * *",
+			},
+			want: "1,16,31,46 1 * * *",
+		},
+		{
+			name: "test6 - invalid minutes definition",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "M/H5 H(22-2) * * *",
+			},
+			wantErrMsg: "cron definition 'M/H5 H(22-2) * * *' is invalid, unable to determine minutes value",
+			wantErr:    true,
+		},
+		{
+			name: "test7 - invalid hour definiton",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "M/15 H(H2-2) * * *",
+			},
+			wantErrMsg: "cron definition 'M/15 H(H2-2) * * *' is invalid, unable to determine hours value",
+			wantErr:    true,
+		},
+		{
+			name: "test8",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "M/15 H(22-2) 3,5 * *",
+			},
+			want: "1,16,31,46 1 3,5 * *",
+		},
+		{
+			name: "test9",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "M/15 H(22-2) * 10-12 *",
+			},
+			want: "1,16,31,46 1 * 10-12 *",
+		},
+		{
+			name: "test10 - invalid dayofweek range",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "M/15 H(22-2) * * 1-8",
+			},
+			wantErrMsg: "cron definition 'M/15 H(22-2) * * 1-8' is invalid, unable to determine day(week) value",
+			wantErr:    true,
+		},
+		{
+			name: "test11",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "15 * * * 1,2,3,6",
+			},
+			want: "15 * * * 1,2,3,6",
+		},
+		{
+			name: "test12",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "15 * 1-31 * *",
+			},
+			want: "15 * 1-31 * *",
+		},
+		{
+			name: "test13 - invalid day range",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "15 * 1-32 * *",
+			},
+			wantErrMsg: "cron definition '15 * 1-32 * *' is invalid, unable to determine days value",
+			wantErr:    true,
+		},
+		{
+			name: "test14 - set hours",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "M/15 23 * * 0-5",
+			},
+			want: "1,16,31,46 23 * * 0-5",
+		},
+		{
+			name: "test15 - set day",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "M/15 * 31 * 0-5",
+			},
+			want: "1,16,31,46 * 31 * 0-5",
+		},
+		{
+			name: "test16 - set month",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "M/15 * * 11 0-5",
+			},
+			want: "1,16,31,46 * * 11 0-5",
+		},
+		{
+			name: "test17 - hourly interval",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "M */6 * * *",
+			},
+			want: "31 1,7,13,19 * * *",
+		},
+		{
+			name: "test18 - day and month string",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "M */6 * JAN MON",
+			},
+			want: "31 1,7,13,19 * JAN MON",
+		},
+		{
+			name: "test19 - whitespace",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "M * * * * ",
+			},
+			want: "31 * * * *",
+		},
+		{
+			name: "test20 - not enough fields",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "*/1 * * *",
+			},
+			wantErrMsg: "cron definition '*/1 * * *' is invalid, 4 fields provided, required 5",
+			wantErr:    true,
+		},
+		{
+			name: "test21 - too many fields",
+			args: args{
+				namespace: "example-com-main",
+				cron:      "*/1 * * * * 7",
+			},
+			wantErrMsg: "cron definition '*/1 * * * * 7' is invalid, 6 fields provided, required 5",
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConvertCrontab(tt.args.namespace, tt.args.cron)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("ConvertCrontab() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErrMsg) {
+					t.Errorf("ConvertCrontab() error = %v, wantErr %v", err.Error(), tt.wantErrMsg)
+				}
+			}
+			if got != tt.want {
+				if !tt.wantErr {
+					t.Errorf("ConvertCrontab() = %v, want %v", got, tt.want)
+				} else {
+					t.Errorf("ConvertCrontab() = %v, wantErr %v", got, tt.wantErr)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This can be used by other tools to ensure cronjob validations across Lagoon tools is consistent. Currently the `build-deploy-tool`, and soon `remote-controller` will be able to use this to validate cron schedules.