### PR TITLE
refactor: implement workaround for id replacement queries

### DIFF
--- a/api/lagoon/client/_lgraphql/projects/projectsByOrganizationName.graphql
+++ b/api/lagoon/client/_lgraphql/projects/projectsByOrganizationName.graphql
@@ -1,0 +1,12 @@
+query (
+  $id: Int!) {
+  organizationByName(
+    id: $id) {
+    projects {
+      id
+      name
+      organization
+      groupCount
+    }
+  }
+}

--- a/api/lagoon/client/_lgraphql/projects/veryMinimalProjectByName.graphql
+++ b/api/lagoon/client/_lgraphql/projects/veryMinimalProjectByName.graphql
@@ -1,0 +1,9 @@
+query (
+  $name: String!) {
+    projectByName(
+      name: $name) {
+        id
+        name
+        organization
+      }
+  }

--- a/api/lagoon/client/deploytargetconfigs.go
+++ b/api/lagoon/client/deploytargetconfigs.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/uselagoon/machinery/api/schema"
 )
@@ -9,7 +10,7 @@ import (
 // DeployTargetConfigsByProjectID queries the Lagoon API for a projects deploytarget configs by its id, and
 // unmarshals the response into deploytargetconfigs.
 func (c *Client) DeployTargetConfigsByProjectID(
-	ctx context.Context, project int, deploytargetconfigs *[]schema.DeployTargetConfig) error {
+	ctx context.Context, project uint, deploytargetconfigs *[]schema.DeployTargetConfig) error {
 	req, err := c.newRequest("_lgraphql/deploytargetconfigs/deployTargetConfigsByProjectId.graphql",
 		map[string]interface{}{
 			"project": project,
@@ -25,6 +26,21 @@ func (c *Client) DeployTargetConfigsByProjectID(
 	})
 }
 
+// DeployTargetConfigsByProjectName is the same as DeployTargetConfigsByProjectID but does a project lookup before the deployments call
+func (c *Client) DeployTargetConfigsByProjectName(
+	ctx context.Context, projectName string, deploytargetconfigs *[]schema.DeployTargetConfig) error {
+	project := &schema.Project{}
+	if err := c.veryMinimalProjectByName(ctx, projectName, project); err != nil {
+		return err
+	}
+	if project.Name == "" {
+		//lint:ignore ST1005 return a generic Lagoon API unauthorized error based on the permission called
+		// this is because organizationbyname will return null instead of an error, the api should probably return an error
+		return fmt.Errorf(`Unauthorized: You don't have permission to "view" on "project"`)
+	}
+	return c.DeployTargetConfigsByProjectID(ctx, project.ID, deploytargetconfigs)
+}
+
 // AddDeployTargetConfiguration adds a deploytarget configuration to a project.
 func (c *Client) AddDeployTargetConfiguration(ctx context.Context,
 	in *schema.AddDeployTargetConfigInput, out *schema.DeployTargetConfig) error {
@@ -37,6 +53,23 @@ func (c *Client) AddDeployTargetConfiguration(ctx context.Context,
 	}{
 		Response: out,
 	})
+}
+
+// AddDeployTargetConfiguration adds a deploytarget configuration to a project.
+func (c *Client) AddDeployTargetConfigurationByProjectName(ctx context.Context,
+	projectName string,
+	in *schema.AddDeployTargetConfigInput, out *schema.DeployTargetConfig) error {
+	project := &schema.Project{}
+	if err := c.veryMinimalProjectByName(ctx, projectName, project); err != nil {
+		return err
+	}
+	if project.Name == "" {
+		//lint:ignore ST1005 return a generic Lagoon API unauthorized error based on the permission called
+		// this is because organizationbyname will return null instead of an error, the api should probably return an error
+		return fmt.Errorf(`Unauthorized: You don't have permission to "view" on "project"`)
+	}
+	in.Project = project.ID
+	return c.AddDeployTargetConfiguration(ctx, in, out)
 }
 
 // UpdateDeployTargetConfiguration adds a deploytarget configuration to a project.
@@ -55,7 +88,7 @@ func (c *Client) UpdateDeployTargetConfiguration(ctx context.Context,
 
 // DeleteDeployTargetConfig deletes a deploytarget config from a project.
 func (c *Client) DeleteDeployTargetConfiguration(ctx context.Context,
-	id int, project int, out *schema.DeleteDeployTargetConfig) error {
+	id, project uint, out *schema.DeleteDeployTargetConfig) error {
 	req, err := c.newRequest("_lgraphql/deploytargetconfigs/deleteDeployTargetConfig.graphql",
 		map[string]interface{}{
 			"id":      id,
@@ -65,4 +98,19 @@ func (c *Client) DeleteDeployTargetConfiguration(ctx context.Context,
 		return err
 	}
 	return c.client.Run(ctx, req, &out)
+}
+
+// DeleteDeployTargetConfigurationByIDAndProjectName is the same as DeleteDeployTargetConfig but does a project lookup before the deployments call
+func (c *Client) DeleteDeployTargetConfigurationByIDAndProjectName(ctx context.Context,
+	id uint, projectName string, out *schema.DeleteDeployTargetConfig) error {
+	project := &schema.Project{}
+	if err := c.veryMinimalProjectByName(ctx, projectName, project); err != nil {
+		return err
+	}
+	if project.Name == "" {
+		//lint:ignore ST1005 return a generic Lagoon API unauthorized error based on the permission called
+		// this is because organizationbyname will return null instead of an error, the api should probably return an error
+		return fmt.Errorf(`Unauthorized: You don't have permission to "view" on "project"`)
+	}
+	return c.DeleteDeployTargetConfiguration(ctx, id, project.ID, out)
 }

--- a/api/lagoon/client/environments.go
+++ b/api/lagoon/client/environments.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/uselagoon/machinery/api/schema"
 )
@@ -69,6 +70,20 @@ func (c *Client) EnvironmentByName(ctx context.Context, name string,
 	}{
 		Response: environment,
 	})
+}
+
+func (c *Client) EnvironmentByNameAndProjectName(ctx context.Context, name string,
+	projectName string, environment *schema.Environment) error {
+	project := &schema.Project{}
+	if err := c.veryMinimalProjectByName(ctx, projectName, project); err != nil {
+		return err
+	}
+	if project.Name == "" {
+		//lint:ignore ST1005 return a generic Lagoon API unauthorized error based on the permission called
+		// this is because organizationbyname will return null instead of an error, the api should probably return an error
+		return fmt.Errorf(`Unauthorized: You don't have permission to "view" on "project"`)
+	}
+	return c.EnvironmentByName(ctx, name, project.ID, environment)
 }
 
 // EnvironmentByID queries the Lagoon API for an environment by its ID and unmarshals the response into environment.
@@ -175,6 +190,20 @@ func (c *Client) BackupsForEnvironmentByName(ctx context.Context, name string,
 	}{
 		Response: environment,
 	})
+}
+
+func (c *Client) BackupsForEnvironmentByNameAndProjectName(ctx context.Context, name string,
+	projectName string, environment *schema.Environment) error {
+	project := &schema.Project{}
+	if err := c.veryMinimalProjectByName(ctx, projectName, project); err != nil {
+		return err
+	}
+	if project.Name == "" {
+		//lint:ignore ST1005 return a generic Lagoon API unauthorized error based on the permission called
+		// this is because organizationbyname will return null instead of an error, the api should probably return an error
+		return fmt.Errorf(`Unauthorized: You don't have permission to "view" on "project"`)
+	}
+	return c.BackupsForEnvironmentByName(ctx, name, project.ID, environment)
 }
 
 // AddRestore adds a restore.

--- a/api/lagoon/client/tasks.go
+++ b/api/lagoon/client/tasks.go
@@ -167,6 +167,21 @@ func (c *Client) TasksByEnvironment(ctx context.Context, projectID uint, environ
 	})
 }
 
+// TasksByEnvironmentAndProjectName is the same as TasksByEnvironment but does a project lookup first
+func (c *Client) TasksByEnvironmentAndProjectName(ctx context.Context, name string,
+	projectName string, environment *schema.Environment) error {
+	project := &schema.Project{}
+	if err := c.veryMinimalProjectByName(ctx, projectName, project); err != nil {
+		return err
+	}
+	if project.Name == "" {
+		//lint:ignore ST1005 return a generic Lagoon API unauthorized error based on the permission called
+		// this is because organizationbyname will return null instead of an error, the api should probably return an error
+		return fmt.Errorf(`Unauthorized: You don't have permission to "view" on "project"`)
+	}
+	return c.TasksByEnvironment(ctx, project.ID, name, environment)
+}
+
 // InvokableAdvancedTaskDefinitionsByEnvironment gets tasks for an environment.
 func (c *Client) InvokableAdvancedTaskDefinitionsByEnvironment(ctx context.Context, projectID uint, environmentName string, environment *schema.Environment) error {
 	req, err := c.newRequest("_lgraphql/tasks/getInvokableAdvancedTaskDefinitionsByEnvironment.graphql",
@@ -183,6 +198,21 @@ func (c *Client) InvokableAdvancedTaskDefinitionsByEnvironment(ctx context.Conte
 	}{
 		Response: environment,
 	})
+}
+
+// InvokableAdvancedTaskDefinitionsByEnvironmentAndProjectName is the same as InvokableAdvancedTaskDefinitionsByEnvironment but does a project lookup first
+func (c *Client) InvokableAdvancedTaskDefinitionsByEnvironmentAndProjectName(ctx context.Context, name string,
+	projectName string, environment *schema.Environment) error {
+	project := &schema.Project{}
+	if err := c.veryMinimalProjectByName(ctx, projectName, project); err != nil {
+		return err
+	}
+	if project.Name == "" {
+		//lint:ignore ST1005 return a generic Lagoon API unauthorized error based on the permission called
+		// this is because organizationbyname will return null instead of an error, the api should probably return an error
+		return fmt.Errorf(`Unauthorized: You don't have permission to "view" on "project"`)
+	}
+	return c.InvokableAdvancedTaskDefinitionsByEnvironment(ctx, project.ID, name, environment)
 }
 
 // InvokeAdvancedTaskDefinition invokes an advanced task definition.

--- a/api/lagoon/deployment.go
+++ b/api/lagoon/deployment.go
@@ -19,6 +19,8 @@ type Deploy interface {
 	DeploymentByRemoteID(ctx context.Context, remoteID string, deployments *schema.Deployment) error
 	DeploymentByName(ctx context.Context, projectName, environmentName, deploymentName string, logs bool, deployments *schema.Deployment) error
 	UpdateDeployment(ctx context.Context, id int, patch schema.UpdateDeploymentPatchInput, result *schema.Deployment) error
+
+	DeploymentsByEnvironmentAndProjectName(ctx context.Context, projectName, environmentName string, environment *schema.Environment) error
 }
 
 // DeployLatest deploys the latest environment.
@@ -55,6 +57,12 @@ func GetDeploymentsByBulkID(ctx context.Context, bulkID string, d Deploy) (*[]sc
 func GetDeploymentsByEnvironment(ctx context.Context, projectID uint, environmentName string, d Deploy) (*schema.Environment, error) {
 	environment := schema.Environment{}
 	return &environment, d.DeploymentsByEnvironment(ctx, projectID, environmentName, &environment)
+}
+
+// GetDeploymentsByEnvironment gets deployments for an environment.
+func GetDeploymentsByEnvironmentAndProjectName(ctx context.Context, projectName, environmentName string, d Deploy) (*schema.Environment, error) {
+	environment := schema.Environment{}
+	return &environment, d.DeploymentsByEnvironmentAndProjectName(ctx, projectName, environmentName, &environment)
 }
 
 // GetDeploymentsByBulkID gets deployments for a given bulkID.

--- a/api/lagoon/deploytargetconfig.go
+++ b/api/lagoon/deploytargetconfig.go
@@ -10,22 +10,38 @@ import (
 
 // DeployTargetConfigs interface contains methods for getting info on deploytarget configs.
 type DeployTargetConfigs interface {
-	DeployTargetConfigsByProjectID(ctx context.Context, project int, deployTargets *[]schema.DeployTargetConfig) error
+	DeployTargetConfigsByProjectID(ctx context.Context, project uint, deployTargets *[]schema.DeployTargetConfig) error
 	AddDeployTargetConfiguration(ctx context.Context, in *schema.AddDeployTargetConfigInput, deployTargets *schema.DeployTargetConfig) error
 	UpdateDeployTargetConfiguration(ctx context.Context, in *schema.UpdateDeployTargetConfigInput, deployTargets *schema.DeployTargetConfig) error
-	DeleteDeployTargetConfiguration(ctx context.Context, id int, project int, deployTargets *schema.DeleteDeployTargetConfig) error
+	DeleteDeployTargetConfiguration(ctx context.Context, id, project uint, deployTargets *schema.DeleteDeployTargetConfig) error
+
+	DeployTargetConfigsByProjectName(ctx context.Context, project string, deployTargets *[]schema.DeployTargetConfig) error
+	AddDeployTargetConfigurationByProjectName(ctx context.Context, project string, in *schema.AddDeployTargetConfigInput, deployTargets *schema.DeployTargetConfig) error
+	DeleteDeployTargetConfigurationByIDAndProjectName(ctx context.Context, id uint, project string, deployTargets *schema.DeleteDeployTargetConfig) error
 }
 
 // GetDeployTargetConfigs gets deploytarget configs for a specific project.
-func GetDeployTargetConfigs(ctx context.Context, project int, dtc DeployTargetConfigs) (*[]schema.DeployTargetConfig, error) {
+func GetDeployTargetConfigs(ctx context.Context, project uint, dtc DeployTargetConfigs) (*[]schema.DeployTargetConfig, error) {
 	deployTargets := []schema.DeployTargetConfig{}
 	return &deployTargets, dtc.DeployTargetConfigsByProjectID(ctx, project, &deployTargets)
+}
+
+// GetDeployTargetConfigs gets deploytarget configs for a specific project.
+func GetDeployTargetConfigsByProjectName(ctx context.Context, project string, dtc DeployTargetConfigs) (*[]schema.DeployTargetConfig, error) {
+	deployTargets := []schema.DeployTargetConfig{}
+	return &deployTargets, dtc.DeployTargetConfigsByProjectName(ctx, project, &deployTargets)
 }
 
 // AddDeployTargetConfiguration adds a deploytarget config to a specific project.
 func AddDeployTargetConfiguration(ctx context.Context, in *schema.AddDeployTargetConfigInput, dtc DeployTargetConfigs) (*schema.DeployTargetConfig, error) {
 	deployTarget := schema.DeployTargetConfig{}
 	return &deployTarget, dtc.AddDeployTargetConfiguration(ctx, in, &deployTarget)
+}
+
+// AddDeployTargetConfiguration adds a deploytarget config to a specific project.
+func AddDeployTargetConfigurationByProjectName(ctx context.Context, project string, in *schema.AddDeployTargetConfigInput, dtc DeployTargetConfigs) (*schema.DeployTargetConfig, error) {
+	deployTarget := schema.DeployTargetConfig{}
+	return &deployTarget, dtc.AddDeployTargetConfigurationByProjectName(ctx, project, in, &deployTarget)
 }
 
 // UpdateDeployTargetConfiguration adds a deploytarget config to a specific project.
@@ -35,7 +51,13 @@ func UpdateDeployTargetConfiguration(ctx context.Context, in *schema.UpdateDeplo
 }
 
 // DeleteDeployTargetConfiguration deletes a deploytarget config from a specific project.
-func DeleteDeployTargetConfiguration(ctx context.Context, id int, project int, dtc DeployTargetConfigs) (*schema.DeleteDeployTargetConfig, error) {
+func DeleteDeployTargetConfiguration(ctx context.Context, id uint, project uint, dtc DeployTargetConfigs) (*schema.DeleteDeployTargetConfig, error) {
 	deployTarget := schema.DeleteDeployTargetConfig{}
 	return &deployTarget, dtc.DeleteDeployTargetConfiguration(ctx, id, project, &deployTarget)
+}
+
+// DeleteDeployTargetConfigurationByIDAndProjectName deletes a deploytarget config from a specific project.
+func DeleteDeployTargetConfigurationByIDAndProjectName(ctx context.Context, id uint, project string, dtc DeployTargetConfigs) (*schema.DeleteDeployTargetConfig, error) {
+	deployTarget := schema.DeleteDeployTargetConfig{}
+	return &deployTarget, dtc.DeleteDeployTargetConfigurationByIDAndProjectName(ctx, id, project, &deployTarget)
 }

--- a/api/lagoon/environments.go
+++ b/api/lagoon/environments.go
@@ -10,7 +10,7 @@ import (
 
 // Environments interface contains methods for getting info on environments.
 type Environments interface {
-	BackupsForEnvironmentByName(context.Context, string, uint, *schema.Environment) error
+	BackupsForEnvironmentByName(ctx context.Context, name string, projectID uint, environment *schema.Environment) error
 	AddRestore(context.Context, string, *schema.Restore) error
 	UpdateEnvironmentStorage(ctx context.Context, storage *schema.UpdateEnvironmentStorageInput, result *schema.UpdateEnvironmentStorage) error
 	UpdateStorageOnEnvironment(ctx context.Context, storage *schema.UpdateStorageOnEnvironmentInput, result *schema.UpdateStorageOnEnvironment) error
@@ -26,12 +26,21 @@ type Environments interface {
 	AddOrUpdateEnvironmentService(ctx context.Context, service schema.AddEnvironmentServiceInput, result *schema.EnvironmentService) error
 	DeleteEnvironmentService(ctx context.Context, service schema.DeleteEnvironmentServiceInput, result *schema.DeleteEnvironmentService) error
 	DeleteBackup(context.Context, string, *schema.DeleteBackup) error
+
+	EnvironmentByNameAndProjectName(ctx context.Context, name, projectName string, result *schema.Environment) error
+	BackupsForEnvironmentByNameAndProjectName(ctx context.Context, name, project string, environment *schema.Environment) error
 }
 
 // GetBackupsForEnvironmentByName gets backup info in lagoon for specific environment.
 func GetBackupsForEnvironmentByName(ctx context.Context, name string, project uint, e Environments) (*schema.Environment, error) {
 	environment := schema.Environment{}
 	return &environment, e.BackupsForEnvironmentByName(ctx, name, project, &environment)
+}
+
+// GetBackupsForEnvironmentByNameAndProjectName gets backup info in lagoon for specific environment.
+func GetBackupsForEnvironmentByNameAndProjectName(ctx context.Context, name, project string, e Environments) (*schema.Environment, error) {
+	environment := schema.Environment{}
+	return &environment, e.BackupsForEnvironmentByNameAndProjectName(ctx, name, project, &environment)
 }
 
 // AddBackupRestore adds a backup restore based on backup ID.
@@ -74,6 +83,12 @@ func SetEnvironmentServices(ctx context.Context, id uint, services []string, e E
 func GetEnvironmentByName(ctx context.Context, name string, project uint, e Environments) (*schema.Environment, error) {
 	environment := schema.Environment{}
 	return &environment, e.EnvironmentByName(ctx, name, project, &environment)
+}
+
+// GetMinimalProjectByName gets info of projects in lagoon that have matching metadata.
+func GetEnvironmentByNameAndProjectName(ctx context.Context, name string, project string, e Environments) (*schema.Environment, error) {
+	environment := schema.Environment{}
+	return &environment, e.EnvironmentByNameAndProjectName(ctx, name, project, &environment)
 }
 
 // GetMinimalProjectByName gets info of projects in lagoon that have matching metadata.

--- a/api/lagoon/projects.go
+++ b/api/lagoon/projects.go
@@ -13,21 +13,26 @@ type Projects interface {
 	MinimalProjectByName(ctx context.Context, name string, project *schema.Project) error
 	ProjectByNameMetadata(ctx context.Context, name string, project *schema.ProjectMetadata) error
 	ProjectsByMetadata(ctx context.Context, key string, value string, project *[]schema.ProjectMetadata) error
-	UpdateProjectMetadata(ctx context.Context, id int, key string, value string, project *schema.ProjectMetadata) error
-	RemoveProjectMetadataByKey(ctx context.Context, id int, key string, project *schema.ProjectMetadata) error
+	UpdateProjectMetadata(ctx context.Context, id uint, key string, value string, project *schema.ProjectMetadata) error
+	RemoveProjectMetadataByKey(ctx context.Context, id uint, key string, project *schema.ProjectMetadata) error
 	NotificationsForProjectByName(ctx context.Context, name string, result *schema.Project) error
-	UpdateProject(ctx context.Context, id int, patch schema.UpdateProjectPatchInput, project *schema.Project) error
+	UpdateProject(ctx context.Context, id uint, patch schema.UpdateProjectPatchInput, project *schema.Project) error
 	SSHEndpointsByProject(ctx context.Context, name string, project *schema.Project) error
 	ProjectGroups(ctx context.Context, name string, project *schema.Project) error
 	ProjectByNameExtended(ctx context.Context, name string, project *schema.Project) error
-	ProjectsByOrganizationID(ctx context.Context, name uint, project *[]schema.OrgProject) error
+	ProjectsByOrganizationID(ctx context.Context, id uint, project *[]schema.OrgProject) error
+	ProjectsByOrganizationName(ctx context.Context, name string, project *[]schema.OrgProject) error
 	RemoveProjectFromOrganization(ctx context.Context, in *schema.RemoveProjectFromOrganizationInput, out *schema.Project) error
 	ProjectKeyByName(ctx context.Context, name string, revealKey bool, project *schema.Project) error
 	AllProjects(ctx context.Context, project *[]schema.Project) error
 	DeleteProject(ctx context.Context, project string, result *schema.DeleteProject) error
+
+	UpdateProjectByName(ctx context.Context, name string, patch schema.UpdateProjectPatchInput, project *schema.Project) error
+	UpdateProjectMetadataByName(ctx context.Context, name string, key string, value string, project *schema.ProjectMetadata) error
+	RemoveProjectMetadataByKeyByName(ctx context.Context, name string, key string, project *schema.ProjectMetadata) error
 }
 
-// GetMinimalProjectByName gets info of projects in lagoon that have matching metadata.
+// GetMinimalProjectByName gets basic information about the project including the openshift id.
 func GetMinimalProjectByName(ctx context.Context, name string, p Projects) (*schema.Project, error) {
 	project := schema.Project{}
 	return &project, p.MinimalProjectByName(ctx, name, &project)
@@ -46,15 +51,27 @@ func GetProjectMetadata(ctx context.Context, name string, p Projects) (*schema.P
 }
 
 // UpdateProjectMetadata updates a project with provided metadata.
-func UpdateProjectMetadata(ctx context.Context, id int, key string, value string, p Projects) (*schema.ProjectMetadata, error) {
+func UpdateProjectMetadata(ctx context.Context, id uint, key string, value string, p Projects) (*schema.ProjectMetadata, error) {
 	project := schema.ProjectMetadata{}
 	return &project, p.UpdateProjectMetadata(ctx, id, key, value, &project)
 }
 
+// UpdateProjectMetadataByName updates a project with provided metadata.
+func UpdateProjectMetadataByName(ctx context.Context, name string, key string, value string, p Projects) (*schema.ProjectMetadata, error) {
+	project := schema.ProjectMetadata{}
+	return &project, p.UpdateProjectMetadataByName(ctx, name, key, value, &project)
+}
+
 // RemoveProjectMetadataByKey remove metadata from a project by key.
-func RemoveProjectMetadataByKey(ctx context.Context, id int, key string, p Projects) (*schema.ProjectMetadata, error) {
+func RemoveProjectMetadataByKey(ctx context.Context, id uint, key string, p Projects) (*schema.ProjectMetadata, error) {
 	project := schema.ProjectMetadata{}
 	return &project, p.RemoveProjectMetadataByKey(ctx, id, key, &project)
+}
+
+// RemoveProjectMetadataByKey remove metadata from a project by key.
+func RemoveProjectMetadataByKeyByName(ctx context.Context, name string, key string, p Projects) (*schema.ProjectMetadata, error) {
+	project := schema.ProjectMetadata{}
+	return &project, p.RemoveProjectMetadataByKeyByName(ctx, name, key, &project)
 }
 
 // NotificationsForProject gets notifications for a project.
@@ -64,9 +81,15 @@ func NotificationsForProject(ctx context.Context, name string, p Projects) (*sch
 }
 
 // UpdateProject updates a project with provided patch data.
-func UpdateProject(ctx context.Context, id int, patch schema.UpdateProjectPatchInput, p Projects) (*schema.Project, error) {
+func UpdateProject(ctx context.Context, id uint, patch schema.UpdateProjectPatchInput, p Projects) (*schema.Project, error) {
 	project := schema.Project{}
 	return &project, p.UpdateProject(ctx, id, patch, &project)
+}
+
+// UpdateProjectByName updates a project with provided patch data.
+func UpdateProjectByName(ctx context.Context, name string, patch schema.UpdateProjectPatchInput, p Projects) (*schema.Project, error) {
+	project := schema.Project{}
+	return &project, p.UpdateProjectByName(ctx, name, patch, &project)
 }
 
 // GetSSHEndpointsByProject gets info of projects in lagoon that have matching metadata.
@@ -91,6 +114,12 @@ func GetProjectByName(ctx context.Context, name string, p Projects) (*schema.Pro
 func ListProjectsByOrganizationID(ctx context.Context, id uint, p Projects) (*[]schema.OrgProject, error) {
 	project := []schema.OrgProject{}
 	return &project, p.ProjectsByOrganizationID(ctx, id, &project)
+}
+
+// ListProjectsByOrganizationName gets projects associated with an organization in lagoon via provided name.
+func ListProjectsByOrganizationName(ctx context.Context, name string, p Projects) (*[]schema.OrgProject, error) {
+	project := []schema.OrgProject{}
+	return &project, p.ProjectsByOrganizationName(ctx, name, &project)
 }
 
 // RemoveProjectFromOrganization removes a project from an organization.

--- a/api/lagoon/tasks.go
+++ b/api/lagoon/tasks.go
@@ -19,6 +19,9 @@ type Tasks interface {
 	InvokeAdvancedTaskDefinition(ctx context.Context, environmentID uint, taskID uint, result *schema.Task) error
 	AdvancedTasksByEnvironment(ctx context.Context, projectID uint, environmentName string, environment *schema.Environment) error
 	AddTask(ctx context.Context, environmentID uint, task schema.Task, result *schema.Task) error
+
+	TasksByEnvironmentAndProjectName(ctx context.Context, project, environmentName string, environment *schema.Environment) error
+	InvokableAdvancedTaskDefinitionsByEnvironmentAndProjectName(ctx context.Context, projectName, environmentName string, environment *schema.Environment) error
 }
 
 // ActiveStandbySwitch runs the activestandby switch.
@@ -51,10 +54,22 @@ func GetTasksByEnvironment(ctx context.Context, projectID uint, environmentName 
 	return &environment, t.TasksByEnvironment(ctx, projectID, environmentName, &environment)
 }
 
+// GetTasksByEnvironmentAndProjectName gets tasks for an environment.
+func GetTasksByEnvironmentAndProjectName(ctx context.Context, projectName, environmentName string, t Tasks) (*schema.Environment, error) {
+	environment := schema.Environment{}
+	return &environment, t.TasksByEnvironmentAndProjectName(ctx, projectName, environmentName, &environment)
+}
+
 // GetInvokableAdvancedTaskDefinitionsByEnvironment gets a list of tasks invokable against an environment.
 func GetInvokableAdvancedTaskDefinitionsByEnvironment(ctx context.Context, projectID uint, environmentName string, t Tasks) (*schema.Environment, error) {
 	environment := schema.Environment{}
 	return &environment, t.InvokableAdvancedTaskDefinitionsByEnvironment(ctx, projectID, environmentName, &environment)
+}
+
+// GetInvokableAdvancedTaskDefinitionsByEnvironment gets a list of tasks invokable against an environment.
+func GetInvokableAdvancedTaskDefinitionsByEnvironmentAndProjectName(ctx context.Context, projectName, environmentName string, t Tasks) (*schema.Environment, error) {
+	environment := schema.Environment{}
+	return &environment, t.InvokableAdvancedTaskDefinitionsByEnvironmentAndProjectName(ctx, projectName, environmentName, &environment)
 }
 
 // InvokeAdvancedTaskDefinition invokes an advanced task definition.


### PR DESCRIPTION
A lot of queries in the API require the project ID, not the name. This is a work around to implement queries that support the name as an input instead of the ID by doing a `veryMinimalProjectByName` request before performing the actual query/mutation.

Previously the lagoon-cli would do a `minimalProjectByName` query before some requests to get the project ID without the user having to remember it, but this requests the `openshift` ID which organization owners currently can't see, so rather than break the query in machinery, this implements a new lightweight `veryMinimalProjectByName` which is internal to machinery only.

Ideally, the API would get updated to have `name` in requests instead of `id`, but this way when the API eventually does support it, these new functions can just be refactored to use the updated API instead of doing the `veryMinimalProjectByName` request first. The organization owner/admin role should also be updated to be able to view which `openshift` a project is configured to use, but again that would take time to implement, where machinery is quicker for now.