### PR TITLE
Change: Removes newVersionedRequest

### DIFF
--- a/api/lagoon/client/_lgraphql/environments/environmentById.graphql
+++ b/api/lagoon/client/_lgraphql/environments/environmentById.graphql
@@ -33,14 +33,12 @@ query (
     services{
       id
       name
-      {{ if apiVerGreaterThanOrEqual . "2.18.0" }}
       type
       containers{
         name
       }
       created
       updated
-      {{ end }}
     }
   }
 }

--- a/api/lagoon/client/_lgraphql/environments/environmentByName.graphql
+++ b/api/lagoon/client/_lgraphql/environments/environmentByName.graphql
@@ -35,14 +35,12 @@ query (
     services{
       id
       name
-      {{ if apiVerGreaterThanOrEqual . "2.18.0" }}
       type
       containers{
         name
       }
       created
       updated
-      {{ end }}
     }
   }
 }

--- a/api/lagoon/client/_lgraphql/environments/environmentByNamespace.graphql
+++ b/api/lagoon/client/_lgraphql/environments/environmentByNamespace.graphql
@@ -33,14 +33,12 @@ query (
     services{
       id
       name
-      {{ if apiVerGreaterThanOrEqual . "2.18.0" }}
       type
       containers{
         name
       }
       created
       updated
-      {{ end }}
     }
   }
 }

--- a/api/lagoon/client/_lgraphql/environments/environmentsByProjectName.graphql
+++ b/api/lagoon/client/_lgraphql/environments/environmentsByProjectName.graphql
@@ -32,14 +32,12 @@ query (
         services{
           id
           name
-          {{ if apiVerGreaterThanOrEqual . "2.18.0" }}
           type
           containers{
             name
           }
           created
           updated
-          {{ end }}
         }
       }
     }

--- a/api/lagoon/client/_lgraphql/environments/updateEnvironment.graphql
+++ b/api/lagoon/client/_lgraphql/environments/updateEnvironment.graphql
@@ -20,14 +20,12 @@ mutation (
         services{
             id
             name
-            {{ if apiVerGreaterThanOrEqual . "2.18.0" }}
             type
             containers{
                 name
             }
             created
             updated
-            {{ end }}
         }
     }
 }

--- a/api/lagoon/client/client.go
+++ b/api/lagoon/client/client.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/hashicorp/go-version"
 	"github.com/machinebox/graphql"
 )
 
@@ -67,47 +66,6 @@ func (c *Client) newRequest(
 	}
 
 	return c.doRequest(string(q), varStruct)
-}
-
-// newVersionedRequest constructs a graphql request which varies based on the version provided.
-// assetName is the name of the graphql query template in _graphql/.
-// varStruct is converted to a map of variables for the template.
-func (c *Client) newVersionedRequest(
-	assetName string, varStruct interface{}) (*graphql.Request, error) {
-
-	q, err := lgraphql.ReadFile(assetName)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't get asset: %w", err)
-	}
-
-	t, err := template.New("query").
-		Funcs(template.FuncMap{
-			// apiVerGreaterThanOrEqual returns true if a is greater than or equal
-			// to b, and false otherwise. a and b should both be valid Semantic
-			// Versions.
-			"apiVerGreaterThanOrEqual": func(a, b string) (bool, error) {
-				aVer, err := version.NewSemver(a)
-				if err != nil {
-					return false, err
-				}
-				bVer, err := version.NewSemver(b)
-				if err != nil {
-					return false, err
-				}
-				return aVer.GreaterThanOrEqual(bVer), nil
-			},
-		}).
-		Parse(string(q))
-	if err != nil {
-		return nil, fmt.Errorf("couldn't parse template: %w", err)
-	}
-
-	queryBuilder := strings.Builder{}
-	if err = t.Execute(&queryBuilder, c.version); err != nil {
-		return nil, fmt.Errorf("couldn't execute template: %w", err)
-	}
-
-	return c.doRequest(queryBuilder.String(), varStruct)
 }
 
 // newTemplateRequest constructs a graphql request which can contain various functions to be templated out

--- a/api/lagoon/client/environments.go
+++ b/api/lagoon/client/environments.go
@@ -56,7 +56,7 @@ func (c *Client) DeleteEnvironment(ctx context.Context,
 func (c *Client) EnvironmentByName(ctx context.Context, name string,
 	projectID uint, environment *schema.Environment) error {
 
-	req, err := c.newVersionedRequest("_lgraphql/environments/environmentByName.graphql",
+	req, err := c.newRequest("_lgraphql/environments/environmentByName.graphql",
 		map[string]interface{}{
 			"name":    name,
 			"project": projectID,
@@ -89,7 +89,7 @@ func (c *Client) EnvironmentByNameAndProjectName(ctx context.Context, name strin
 // EnvironmentByID queries the Lagoon API for an environment by its ID and unmarshals the response into environment.
 func (c *Client) EnvironmentByID(ctx context.Context, environmentID uint, environment *schema.Environment) error {
 
-	req, err := c.newVersionedRequest("_lgraphql/environments/environmentById.graphql",
+	req, err := c.newRequest("_lgraphql/environments/environmentById.graphql",
 		map[string]interface{}{
 			"id": environmentID,
 		})
@@ -108,7 +108,7 @@ func (c *Client) EnvironmentByID(ctx context.Context, environmentID uint, enviro
 // and unmarshals the response into environment.
 func (c *Client) EnvironmentByNamespace(ctx context.Context, namespace string, environment *schema.Environment) error {
 
-	req, err := c.newVersionedRequest("_lgraphql/environments/environmentByNamespace.graphql",
+	req, err := c.newRequest("_lgraphql/environments/environmentByNamespace.graphql",
 		map[string]interface{}{
 			"namespace": namespace,
 		})
@@ -127,7 +127,7 @@ func (c *Client) EnvironmentByNamespace(ctx context.Context, namespace string, e
 // and unmarshals the response into environment.
 func (c *Client) BackupsByEnvironmentNamespace(ctx context.Context, namespace string, environment *schema.Environment) error {
 
-	req, err := c.newVersionedRequest("_lgraphql/environments/backupsByEnvironmentNamespace.graphql",
+	req, err := c.newRequest("_lgraphql/environments/backupsByEnvironmentNamespace.graphql",
 		map[string]interface{}{
 			"namespace": namespace,
 		})
@@ -146,7 +146,7 @@ func (c *Client) BackupsByEnvironmentNamespace(ctx context.Context, namespace st
 // and unmarshals the response into environment.
 func (c *Client) EnvironmentsByProjectName(ctx context.Context, project string, environments *[]schema.Environment) error {
 
-	req, err := c.newVersionedRequest("_lgraphql/environments/environmentsByProjectName.graphql",
+	req, err := c.newRequest("_lgraphql/environments/environmentsByProjectName.graphql",
 		map[string]interface{}{
 			"project": project,
 		})
@@ -241,7 +241,7 @@ func (c *Client) AddOrUpdateEnvironment(ctx context.Context,
 func (c *Client) UpdateEnvironment(
 	ctx context.Context, id uint, patch schema.UpdateEnvironmentPatchInput, environment *schema.Environment) error {
 
-	req, err := c.newVersionedRequest("_lgraphql/environments/updateEnvironment.graphql",
+	req, err := c.newRequest("_lgraphql/environments/updateEnvironment.graphql",
 		map[string]interface{}{
 			"id":    id,
 			"patch": patch,


### PR DESCRIPTION
Removes the api version checks (`apiVerGreaterThanOrEqual`) in several queries & `newVersionedRequest` as it's no longer required with their removal.