### PR TITLE
Change: Adds additional fields to allProjects

### DIFF
--- a/api/lagoon/client/_lgraphql/projects/allProjects.graphql
+++ b/api/lagoon/client/_lgraphql/projects/allProjects.graphql
@@ -5,6 +5,13 @@ query {
     gitUrl
     productionEnvironment
     developmentEnvironmentsLimit
+    autoIdle
+    branches
+    pullrequests
+    routerPattern
+    factsUi
+    problemsUi
+    deploymentsDisabled
     environments{
       id
       name


### PR DESCRIPTION
Adds additional fields to `allProjects` to accomodate support for `--wide` flags.

Required for https://github.com/uselagoon/lagoon-cli/pull/434