### PR TITLE
fix: panic when RetrieveToken finds no auth methods

### DIFF
--- a/utils/sshtoken/sshtoken.go
+++ b/utils/sshtoken/sshtoken.go
@@ -2,6 +2,7 @@ package sshtoken
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -128,6 +129,9 @@ func GetPublicKeyAuthMethod(path string, publicKeyOverride *string, publicKeyIde
 func RetrieveToken(sshKey, sshHost, sshPort string, publicKeyOverride *string, publicKeyIdentities []string, verbose bool) (string, error) {
 	skipAgent := false
 	authMethod, closeSSHAgent := GetPublicKeyAuthMethod(sshKey, publicKeyOverride, publicKeyIdentities, skipAgent, verbose)
+	if authMethod == nil {
+		return "", errors.New("couldn't load ssh key")
+	}
 	config := &ssh.ClientConfig{
 		User: "lagoon",
 		Auth: []ssh.AuthMethod{


### PR DESCRIPTION
If `sshtoken.RetrieveToken` is called with no private key, and no keys in an ssh agent, it will panic because `ssh.AuthMethod` can't have any `nil` values:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x82d9e1]

goroutine 1 [running]:
golang.org/x/crypto/ssh.(*connection).clientAuthenticate(0xc000128280, 0xc000134000)
        ~/go/pkg/mod/golang.org/x/crypto@v0.32.0/ssh/client_auth.go:99 +0x6e1
golang.org/x/crypto/ssh.(*connection).clientHandshake(0xc000128280, {0xc00035e8d0, 0x27}, 0xc000134000)
        ~/go/pkg/mod/golang.org/x/crypto@v0.32.0/ssh/client.go:113 +0x297
golang.org/x/crypto/ssh.NewClientConn({0xc40938, 0xc00012c008}, {0xc00035e8d0, 0x27}, 0xc00020f580)
        ~/go/pkg/mod/golang.org/x/crypto@v0.32.0/ssh/client.go:83 +0x125
golang.org/x/crypto/ssh.Dial({0xb21c8f?, 0x5?}, {0xc00035e8d0, 0x27}, 0xc00020f580)
        ~/go/pkg/mod/golang.org/x/crypto@v0.32.0/ssh/client.go:181 +0x47
github.com/uselagoon/machinery/utils/sshtoken.RetrieveToken({0x0?, 0x4ce960?}, {0xc00035e750, 0x24}, {0xc00037ca84, 0x2}, 0xb30586?, {0x0, 0x0, 0x0}, ...)
        ~/dev/machinery/main/utils/sshtoken/sshtoken.go:147 +0x232
github.com/uselagoon/lagoon-sync/utils.(*ApiConn).Init(0xc00020f9e0, {0xc00023d540, 0x34}, {0x0?, 0xc00037eb10?}, {0xc00035e750, 0x24}, {0xc00037ca84, 0x2})
        ~/dev/lagoon-sync/utils/sshportal.go:25 +0x74
github.com/uselagoon/lagoon-sync/cmd.syncCommandRun(0xc00038c200?, {0xc0000cc4d0?, 0x4?, 0xb2225f?})
        ~/dev/lagoon-sync/cmd/sync.go:219 +0xc49
github.com/spf13/cobra.(*Command).execute(0x11512c0, {0xc0000cc420, 0xb, 0xb})
        ~/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:989 +0xa91
github.com/spf13/cobra.(*Command).ExecuteC(0x1150a20)
        ~/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1117 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        ~/go/pkg/mod/github.com/spf13/cobra@v1.8.1/command.go:1041
github.com/uselagoon/lagoon-sync/cmd.Execute()
        ~/dev/lagoon-sync/cmd/root.go:40 +0x1a
main.main()
        ~/dev/lagoon-sync/main.go:23 +0xf
```

This is easy to reproduce by running pygmy without any ssh keys added, then attempting to run `lagoon-sync`.