### PR TITLE
Change: Extend deployment with sourcetype

### DIFF
--- a/api/lagoon/client/_lgraphql/deployments/deploymentByName.graphql
+++ b/api/lagoon/client/_lgraphql/deployments/deploymentByName.graphql
@@ -12,5 +12,6 @@ query deploymentByName($projectName: String!, $environmentName: String!, $name: 
         bulkId
         bulkName
         buildStep
+        sourceType
     }
 }

--- a/api/lagoon/client/_lgraphql/deployments/deploymentByNameWithLog.graphql
+++ b/api/lagoon/client/_lgraphql/deployments/deploymentByNameWithLog.graphql
@@ -13,5 +13,6 @@ query deploymentByName($projectName: String!, $environmentName: String!, $name: 
         bulkName
         buildStep
         buildLog
+        sourceType
     }
 }

--- a/api/schema/deployment.go
+++ b/api/schema/deployment.go
@@ -8,6 +8,8 @@ import (
 // DeployType .
 type DeployType string
 
+type DeploymentSourceType string
+
 func (d DeployType) validateType() error {
 	deployTypes := map[DeployType]struct{}{
 		Branch:      {},
@@ -29,6 +31,12 @@ const (
 	Branch      DeployType = "BRANCH"
 	PullRequest DeployType = "PULLREQUEST"
 	Promote     DeployType = "PROMOTE"
+)
+
+const (
+	Api     DeploymentSourceType = "API"
+	Webhook DeploymentSourceType = "WEBHOOK"
+	Clone   DeploymentSourceType = "CLONE"
 )
 
 // DeployEnvironmentLatest is the response.
@@ -93,20 +101,21 @@ type DeployEnvironmentLatestInput struct {
 }
 
 type Deployment struct {
-	ID          int              `json:"id,omitempty"`
-	Name        string           `json:"name,omitempty"`
-	Status      string           `json:"status,omitempty"`
-	Created     string           `json:"created,omitempty"`
-	Started     string           `json:"started,omitempty"`
-	Completed   string           `json:"completed,omitempty"`
-	RemoteID    string           `json:"remoteId,omitempty"`
-	BuildLog    string           `json:"buildLog,omitempty"`
-	UILink      string           `json:"uiLink,omitempty"`
-	Priority    uint             `json:"priority,omitempty"`
-	BulkID      string           `json:"bulkId,omitempty"`
-	BulkName    string           `json:"bulkName,omitempty"`
-	BuildStep   string           `json:"buildStep,omitempty"`
-	Environment EnvironmentInput `json:"environment"`
+	ID                   int                  `json:"id,omitempty"`
+	Name                 string               `json:"name,omitempty"`
+	Status               string               `json:"status,omitempty"`
+	Created              string               `json:"created,omitempty"`
+	Started              string               `json:"started,omitempty"`
+	Completed            string               `json:"completed,omitempty"`
+	RemoteID             string               `json:"remoteId,omitempty"`
+	BuildLog             string               `json:"buildLog,omitempty"`
+	UILink               string               `json:"uiLink,omitempty"`
+	Priority             uint                 `json:"priority,omitempty"`
+	BulkID               string               `json:"bulkId,omitempty"`
+	BulkName             string               `json:"bulkName,omitempty"`
+	BuildStep            string               `json:"buildStep,omitempty"`
+	Environment          EnvironmentInput     `json:"environment"`
+	DeploymentSourceType DeploymentSourceType `json:"deploymentSourceType,omitempty"`
 }
 
 type UpdateDeploymentPatchInput struct {

--- a/api/schema/deployment.go
+++ b/api/schema/deployment.go
@@ -115,7 +115,7 @@ type Deployment struct {
 	BulkName             string               `json:"bulkName,omitempty"`
 	BuildStep            string               `json:"buildStep,omitempty"`
 	Environment          EnvironmentInput     `json:"environment"`
-	DeploymentSourceType DeploymentSourceType `json:"deploymentSourceType,omitempty"`
+	DeploymentSourceType DeploymentSourceType `json:"sourceType,omitempty"`
 }
 
 type UpdateDeploymentPatchInput struct {


### PR DESCRIPTION
Extends `Deployment` with `sourceType`. Updates `sourceType` to include `API`, `WEBHOOK` & `CLONE`.